### PR TITLE
Edit add command parsers

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -10,7 +10,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.AddressBookParser;
+import seedu.address.logic.parser.AlfredParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -26,12 +26,12 @@ public class LogicManager implements Logic {
 
     private final Model model;
     private final Storage storage;
-    private final AddressBookParser addressBookParser;
+    private final AlfredParser addressBookParser;
 
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
-        addressBookParser = new AddressBookParser();
+        addressBookParser = new AlfredParser();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AlfredParser.java
+++ b/src/main/java/seedu/address/logic/parser/AlfredParser.java
@@ -22,7 +22,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 /**
  * Parses user input.
  */
-public class AddressBookParser {
+public class AlfredParser {
 
     /**
      * Used for initial separation of command word and args.

--- a/src/main/java/seedu/address/logic/parser/AlfredParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/AlfredParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -160,5 +161,13 @@ public class AlfredParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/addcommandparser/AddMentorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/addcommandparser/AddMentorCommandParser.java
@@ -7,14 +7,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ORGANISATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT_NAME;
 
-import java.util.stream.Stream;
 import seedu.address.logic.commands.addcommand.AddCommand;
 import seedu.address.logic.commands.addcommand.AddMentorCommand;
 import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.entity.Email;
 import seedu.address.model.entity.Id;

--- a/src/main/java/seedu/address/logic/parser/addcommandparser/AddMentorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/addcommandparser/AddMentorCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ORGANISATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT_NAME;
 
-import seedu.address.logic.commands.addcommand.AddCommand;
 import seedu.address.logic.commands.addcommand.AddMentorCommand;
 import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
@@ -25,7 +24,7 @@ import seedu.address.model.entitylist.MentorList;
 /**
  * Parses input arguments and creates a new {@link AddMentorCommand} object.
  */
-public class AddMentorCommandParser implements Parser<AddCommand> {
+public class AddMentorCommandParser implements Parser<AddMentorCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the {@code AddMentorCommand}

--- a/src/main/java/seedu/address/logic/parser/addcommandparser/AddMentorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/addcommandparser/AddMentorCommandParser.java
@@ -1,17 +1,20 @@
 package seedu.address.logic.parser.addcommandparser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ORGANISATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT_NAME;
 
+import java.util.stream.Stream;
 import seedu.address.logic.commands.addcommand.AddCommand;
 import seedu.address.logic.commands.addcommand.AddMentorCommand;
 import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.entity.Email;
 import seedu.address.model.entity.Id;
@@ -35,6 +38,13 @@ public class AddMentorCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ORGANISATION,
                         PREFIX_SUBJECT_NAME);
+
+        if (!AlfredParserUtil.arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_ORGANISATION, PREFIX_SUBJECT_NAME) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    seedu.address.logic.commands.AddCommand.MESSAGE_USAGE));
+        }
+
         Name name = AlfredParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = AlfredParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = AlfredParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());

--- a/src/main/java/seedu/address/logic/parser/addcommandparser/AddParticipantCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/addcommandparser/AddParticipantCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
-import seedu.address.logic.commands.addcommand.AddCommand;
 import seedu.address.logic.commands.addcommand.AddParticipantCommand;
 import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
@@ -22,7 +21,7 @@ import seedu.address.model.entitylist.ParticipantList;
 /**
  * Parses input arguments and creates a new {@link AddParticipantCommand} object.
  */
-public class AddParticipantCommandParser implements Parser<AddCommand> {
+public class AddParticipantCommandParser implements Parser<AddParticipantCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the {@code AddParticipantCommand}

--- a/src/main/java/seedu/address/logic/parser/addcommandparser/AddParticipantCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/addcommandparser/AddParticipantCommandParser.java
@@ -1,15 +1,20 @@
 package seedu.address.logic.parser.addcommandparser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
+import java.util.stream.Stream;
+import seedu.address.logic.commands.addcommand.AddCommand;
 import seedu.address.logic.commands.addcommand.AddParticipantCommand;
 import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
 import seedu.address.model.entity.Email;
 import seedu.address.model.entity.Id;
 import seedu.address.model.entity.Name;
@@ -20,7 +25,7 @@ import seedu.address.model.entitylist.ParticipantList;
 /**
  * Parses input arguments and creates a new {@link AddParticipantCommand} object.
  */
-public class AddParticipantCommandParser implements Parser<AddParticipantCommand> {
+public class AddParticipantCommandParser implements Parser<AddCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the {@code AddParticipantCommand}
@@ -30,11 +35,17 @@ public class AddParticipantCommandParser implements Parser<AddParticipantCommand
     public AddParticipantCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL);
+
+        if (!AlfredParserUtil.arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    seedu.address.logic.commands.AddCommand.MESSAGE_USAGE));
+        }
+
         Name name = AlfredParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = AlfredParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = AlfredParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Id id = new ParticipantList().generateId();
-
         Participant participant = new Participant(name, id, email, phone);
 
         return new AddParticipantCommand(participant);

--- a/src/main/java/seedu/address/logic/parser/addcommandparser/AddParticipantCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/addcommandparser/AddParticipantCommandParser.java
@@ -5,16 +5,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
-import java.util.stream.Stream;
 import seedu.address.logic.commands.addcommand.AddCommand;
 import seedu.address.logic.commands.addcommand.AddParticipantCommand;
 import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.Model;
 import seedu.address.model.entity.Email;
 import seedu.address.model.entity.Id;
 import seedu.address.model.entity.Name;

--- a/src/main/java/seedu/address/logic/parser/addcommandparser/AddTeamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/addcommandparser/AddTeamCommandParser.java
@@ -1,11 +1,8 @@
 package seedu.address.logic.parser.addcommandparser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ORGANISATION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT_NAME;
@@ -13,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT_NAME;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.addcommand.AddCommand;
 import seedu.address.logic.commands.addcommand.AddTeamCommand;
@@ -21,7 +17,6 @@ import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.entity.Id;
 import seedu.address.model.entity.Location;

--- a/src/main/java/seedu/address/logic/parser/addcommandparser/AddTeamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/addcommandparser/AddTeamCommandParser.java
@@ -1,7 +1,11 @@
 package seedu.address.logic.parser.addcommandparser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ORGANISATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT_NAME;
@@ -9,6 +13,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT_NAME;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.addcommand.AddCommand;
 import seedu.address.logic.commands.addcommand.AddTeamCommand;
@@ -16,6 +21,7 @@ import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.entity.Id;
 import seedu.address.model.entity.Location;
@@ -42,6 +48,12 @@ public class AddTeamCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_SUBJECT_NAME, PREFIX_PROJECT_NAME,
                         PREFIX_PROJECT_TYPE, PREFIX_LOCATION);
+
+        if (!AlfredParserUtil.arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PROJECT_NAME, PREFIX_PROJECT_TYPE,
+                PREFIX_LOCATION, PREFIX_SUBJECT_NAME) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    seedu.address.logic.commands.AddCommand.MESSAGE_USAGE));
+        }
 
         Name name = AlfredParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         SubjectName subject = AlfredParserUtil.parseSubject(argMultimap.getValue(PREFIX_SUBJECT_NAME).get());

--- a/src/main/java/seedu/address/logic/parser/addcommandparser/AddTeamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/addcommandparser/AddTeamCommandParser.java
@@ -11,7 +11,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
-import seedu.address.logic.commands.addcommand.AddCommand;
 import seedu.address.logic.commands.addcommand.AddTeamCommand;
 import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
@@ -32,7 +31,7 @@ import seedu.address.model.entitylist.TeamList;
 /**
  * Parses input arguments and creates a new {@link AddTeamCommand} object.
  */
-public class AddTeamCommandParser implements Parser<AddCommand> {
+public class AddTeamCommandParser implements Parser<AddTeamCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -31,7 +31,7 @@ import seedu.address.testutil.PersonUtil;
 
 public class AddressBookParserTest {
 
-    private final AddressBookParser parser = new AddressBookParser();
+    private final AlfredParser parser = new AlfredParser();
 
     @Test
     public void parseCommand_add() throws Exception {


### PR DESCRIPTION
## Description
Adds extra constraints to the add command parsers so that the Alfred recognised when the user has missed one or more field when creating a new entity.

## Checks
- [] No errors when running the tests
- [] Build and checkstyle passes
- [] Run the app and ran 2 commands without failing
- [] Written the baseline test cases for the PR

## Changelog
- []
- []
- []

## Comments for Reviewer (if any)
@hcwong 
@john0227 
@brianyenna 
@Joanna-YJA 