### PR TITLE
Make generateId static and move model initialization to modelManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ targetCompatibility = JavaVersion.VERSION_11
 repositories {
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+    jcenter()
 }
 
 checkstyle {
@@ -66,6 +67,8 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
+
+    compile "org.mockito:mockito-core:2.+"
 }
 
 shadowJar {

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
+
 import javafx.application.Application;
 import javafx.stage.Stage;
 import seedu.address.commons.core.Config;

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -73,11 +73,12 @@ public class MainApp extends Application {
         initLogging(config);
 
         model = new ModelManager(storage, userPrefs);
-        model.initialize();
 
-        logic = new LogicManager(model, storage);
+        logic = new LogicManager(model);
 
         ui = new UiManager(logic);
+
+        model.initialize();
     }
 
     private void initLogging(Config config) {

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -18,18 +18,8 @@ import seedu.address.logic.LogicManager;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.storage.AddressBookStorage;
-//import seedu.address.storage.AlfredStorage;
-import seedu.address.storage.JsonAddressBookStorage;
-//import seedu.address.storage.JsonMentorListStorage;
-//import seedu.address.storage.JsonParticipantListStorage;
-//import seedu.address.storage.JsonTeamListStorage;
+import seedu.address.storage.AlfredStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
-//import seedu.address.storage.MentorListStorage;
-//import seedu.address.storage.ParticipantListStorage;
-import seedu.address.storage.Storage;
-import seedu.address.storage.StorageManager;
-//import seedu.address.storage.TeamListStorage;
 import seedu.address.storage.UserPrefsStorage;
 import seedu.address.ui.Ui;
 import seedu.address.ui.UiManager;
@@ -45,8 +35,7 @@ public class MainApp extends Application {
 
     protected Ui ui;
     protected Logic logic;
-    protected Storage storage;
-    //protected AlfredStorage storage; //TODO: Uncomment this when ready for AlfredStorage integration
+    protected AlfredStorage storage;
     protected Model model;
     protected Config config;
 
@@ -61,8 +50,8 @@ public class MainApp extends Application {
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
         //TODO: Update this with the 4 different EntityLists
-        AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookFilePath());
-        storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        // AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookFilePath());
+        // storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
         //TODO: Uncomment this when ready for AlfredStorage integration
         //ParticipantListStorage pStore = new JsonParticipantListStorage(userPrefs.getParticipantListFilePath());

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -15,14 +15,9 @@ import seedu.address.commons.util.ConfigUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
 import seedu.address.logic.LogicManager;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.UserPrefs;
-//import seedu.address.model.entitylist.MentorList;
-import seedu.address.model.util.SampleDataUtil;
 import seedu.address.storage.AddressBookStorage;
 //import seedu.address.storage.AlfredStorage;
 import seedu.address.storage.JsonAddressBookStorage;
@@ -77,36 +72,12 @@ public class MainApp extends Application {
 
         initLogging(config);
 
-        model = initModelManager(storage, userPrefs);
+        model = new ModelManager(storage, userPrefs);
+        model.initialize();
 
         logic = new LogicManager(model, storage);
 
         ui = new UiManager(logic);
-    }
-
-    /**
-     * Returns a {@code ModelManager} with the data from {@code storage}'s address book and {@code userPrefs}. <br>
-     * The data from the sample address book will be used instead if {@code storage}'s address book is not found,
-     * or an empty address book will be used instead if errors occur when reading {@code storage}'s address book.
-     */
-    private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
-        Optional<ReadOnlyAddressBook> addressBookOptional;
-        ReadOnlyAddressBook initialData;
-        try {
-            addressBookOptional = storage.readAddressBook();
-            if (!addressBookOptional.isPresent()) {
-                logger.info("Data file not found. Will be starting with a sample AddressBook");
-            }
-            initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
-        } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
-            initialData = new AddressBook();
-        } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
-            initialData = new AddressBook();
-        }
-
-        return new ModelManager(initialData, userPrefs);
     }
 
     private void initLogging(Config config) {

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
-
 import javafx.application.Application;
 import javafx.stage.Stage;
 import seedu.address.commons.core.Config;
@@ -19,7 +18,14 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.storage.AlfredStorage;
+import seedu.address.storage.AlfredStorageManager;
+import seedu.address.storage.JsonMentorListStorage;
+import seedu.address.storage.JsonParticipantListStorage;
+import seedu.address.storage.JsonTeamListStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
+import seedu.address.storage.MentorListStorage;
+import seedu.address.storage.ParticipantListStorage;
+import seedu.address.storage.TeamListStorage;
 import seedu.address.storage.UserPrefsStorage;
 import seedu.address.ui.Ui;
 import seedu.address.ui.UiManager;
@@ -49,19 +55,16 @@ public class MainApp extends Application {
 
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
-        //TODO: Update this with the 4 different EntityLists
-        // AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookFilePath());
-        // storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
-        //TODO: Uncomment this when ready for AlfredStorage integration
-        //ParticipantListStorage pStore = new JsonParticipantListStorage(userPrefs.getParticipantListFilePath());
-        //MentorListStorage mStore = new JsonMentorListStorage(userPrefs.getMentorListFilePath());
-        //TeamListStorage tStore = new JsonTeamListStorage(userPrefs.getTeamListFilePath());
-        //storage = new AlfredStorage(pStore, mStore, tStore, userPrefsStorage);
+        ParticipantListStorage pStore = new JsonParticipantListStorage(userPrefs.getParticipantListFilePath());
+        MentorListStorage mStore = new JsonMentorListStorage(userPrefs.getMentorListFilePath());
+        TeamListStorage tStore = new JsonTeamListStorage(userPrefs.getTeamListFilePath());
+        storage = new AlfredStorageManager(pStore, mStore, tStore, userPrefsStorage);
 
         initLogging(config);
 
         model = new ModelManager(storage, userPrefs);
+        model.initialize();
 
         logic = new LogicManager(model);
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -1,6 +1,5 @@
 package seedu.address.logic;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
@@ -15,7 +14,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
-import seedu.address.storage.Storage;
 
 /**
  * The main LogicManager of the app.
@@ -28,7 +26,7 @@ public class LogicManager implements Logic {
     private final Storage storage;
     private final AlfredParser addressBookParser;
 
-    public LogicManager(Model model, Storage storage) {
+    public LogicManager(Model model) {
         this.model = model;
         this.storage = storage;
         addressBookParser = new AlfredParser();
@@ -41,12 +39,6 @@ public class LogicManager implements Logic {
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
-
-        try {
-            storage.saveAddressBook(model.getAddressBook());
-        } catch (IOException ioe) {
-            throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
-        }
 
         return commandResult;
     }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -23,12 +23,10 @@ public class LogicManager implements Logic {
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
     private final Model model;
-    private final Storage storage;
     private final AlfredParser addressBookParser;
 
     public LogicManager(Model model) {
         this.model = model;
-        this.storage = storage;
         addressBookParser = new AlfredParser();
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -21,6 +21,11 @@ public interface Model {
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
     /**
+     * Initializes the model.
+     */
+    void initialize();
+
+    /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
     void setUserPrefs(ReadOnlyUserPrefs userPrefs);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -10,7 +10,7 @@ import seedu.address.model.entity.Id;
 import seedu.address.model.entity.Mentor;
 import seedu.address.model.entity.Participant;
 import seedu.address.model.entity.Team;
-import seedu.address.model.entitylist.ReadableEntityList;
+import seedu.address.model.entitylist.ReadOnlyEntityList;
 import seedu.address.model.person.Person;
 
 /**
@@ -53,17 +53,17 @@ public interface Model {
     /**
      * Returns the ParticipantList.
      */
-    ReadableEntityList getParticipantList();
+    ReadOnlyEntityList getParticipantList();
 
     /**
      * Returns the TeamList.
      */
-    ReadableEntityList getTeamList();
+    ReadOnlyEntityList getTeamList();
 
     /**
      * Returns the MentorList.
      */
-    ReadableEntityList getMentorList();
+    ReadOnlyEntityList getMentorList();
 
     /* Below is the API exposed for the controllers to call */
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -259,10 +259,10 @@ public class ModelManager implements Model {
             throw new AlfredModelException("Participant does not exist");
         }
 
-        Participant participantToDelete = this.participantList.delete(id);
+        Participant deletedParticipant = this.participantList.delete(id);
         this.saveList(PrefixType.P);
         this.saveList(PrefixType.T);
-        return participantToDelete;
+        return deletedParticipant;
     }
 
     /* Team Methods*/
@@ -356,6 +356,7 @@ public class ModelManager implements Model {
             logger.severe("Participant is already present in team");
             throw new AlfredModelException("Participant is already present in team");
         }
+        this.saveList(PrefixType.T);
     }
 
     /**
@@ -374,6 +375,7 @@ public class ModelManager implements Model {
             logger.severe("Team already has a mentor");
             throw new AlfredModelException("Team already has a mentor");
         }
+        this.saveList(PrefixType.T);
     }
 
     /**
@@ -384,9 +386,10 @@ public class ModelManager implements Model {
      * @throws AlfredException
      */
     public Team deleteTeam(Id id) throws AlfredException {
+        Team teamToDelete = this.teamList.delete(id);
         this.saveList(PrefixType.T);
         this.saveList(PrefixType.P);
-        return this.teamList.delete(id);
+        return teamToDelete;
     }
 
     /* Mentor Methods */
@@ -409,8 +412,8 @@ public class ModelManager implements Model {
      * @throws AlfredException
      */
     public void addMentor(Mentor mentor) throws AlfredException {
-        this.saveList(PrefixType.M);
         this.mentorList.add(mentor);
+        this.saveList(PrefixType.M);
     }
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -1,15 +1,11 @@
 package seedu.address.model;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
-
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
@@ -28,6 +24,9 @@ import seedu.address.model.entitylist.TeamList;
 import seedu.address.model.person.Person;
 import seedu.address.storage.AlfredStorage;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
 /**
  * Represents the in-memory model of the address book data.
  */
@@ -42,9 +41,9 @@ public class ModelManager implements Model {
     private FilteredList<Person> filteredPersons = null;
 
     // EntityLists
-    private ParticipantList participantList;
-    private TeamList teamList;
-    private MentorList mentorList;
+    private ParticipantList participantList = new ParticipantList();
+    private TeamList teamList = new TeamList();
+    private MentorList mentorList = new MentorList();
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -68,6 +67,9 @@ public class ModelManager implements Model {
         super();
         this.userPrefs = new UserPrefs(userPrefs);
         this.storage = storage;
+        // TODO: Remove: Currently it is here to make tests pass.
+        this.addressBook = new AddressBook();
+        filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
     }
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -1,11 +1,15 @@
 package seedu.address.model;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
@@ -23,9 +27,6 @@ import seedu.address.model.entitylist.ReadOnlyEntityList;
 import seedu.address.model.entitylist.TeamList;
 import seedu.address.model.person.Person;
 import seedu.address.storage.AlfredStorage;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 /**
  * Represents the in-memory model of the address book data.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,6 +24,7 @@ import seedu.address.model.entitylist.ParticipantList;
 import seedu.address.model.entitylist.ReadOnlyEntityList;
 import seedu.address.model.entitylist.TeamList;
 import seedu.address.model.person.Person;
+import seedu.address.storage.Storage;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -31,14 +32,17 @@ import seedu.address.model.person.Person;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final AddressBook addressBook;
+    // TODO: Remove the null values which are a placeholder due to the multiple constructors.
+    // Also will have to change the relevant attributes to final.
+    private Storage storage = null;
+    private AddressBook addressBook = null;
     private final UserPrefs userPrefs;
-    private final FilteredList<Person> filteredPersons;
+    private FilteredList<Person> filteredPersons = null;
 
     // EntityLists
-    private final ParticipantList participantList;
-    private final TeamList teamList;
-    private final MentorList mentorList;
+    private ParticipantList participantList;
+    private TeamList teamList;
+    private MentorList mentorList;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -52,14 +56,44 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-
-        this.participantList = new ParticipantList();
-        this.teamList = new TeamList();
-        this.mentorList = new MentorList();
     }
 
     public ModelManager() {
         this(new AddressBook(), new UserPrefs());
+    }
+
+    public ModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
+        super();
+        this.userPrefs = new UserPrefs(userPrefs);
+        this.storage = storage;
+
+    }
+
+    /**
+     * Initializes the various lists used. If storage contains no data, it defaults to loading
+     * the sample lists provided.
+     */
+    public void initialize() {
+        this.participantList = new ParticipantList();
+        this.teamList = new TeamList();
+        this.mentorList = new MentorList();
+
+        // TODO: reimplement this logic here.
+        // Optional<ReadOnlyAddressBook> addressBookOptional;
+        // ReadOnlyAddressBook initialData;
+        // try {
+        //    addressBookOptional = storage.readAddressBook();
+        //    if (!addressBookOptional.isPresent()) {
+        //        logger.info("Data file not found. Will be starting with a sample AddressBook");
+        //    }
+        //    initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
+        // } catch (DataConversionException e) {
+        //    logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
+        //    initialData = new AddressBook();
+        // } catch (IOException e) {
+        //    logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
+        //    initialData = new AddressBook();
+        // }
     }
 
     //=========== UserPrefs ==================================================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -21,7 +21,7 @@ import seedu.address.model.entity.Participant;
 import seedu.address.model.entity.Team;
 import seedu.address.model.entitylist.MentorList;
 import seedu.address.model.entitylist.ParticipantList;
-import seedu.address.model.entitylist.ReadableEntityList;
+import seedu.address.model.entitylist.ReadOnlyEntityList;
 import seedu.address.model.entitylist.TeamList;
 import seedu.address.model.person.Person;
 
@@ -104,7 +104,7 @@ public class ModelManager implements Model {
      *
      * @return ReadableEntityList
      */
-    public ReadableEntityList getParticipantList() {
+    public ReadOnlyEntityList getParticipantList() {
         return this.participantList;
     }
 
@@ -113,7 +113,7 @@ public class ModelManager implements Model {
      *
      * @return ReadableEntityList
      */
-    public ReadableEntityList getTeamList() {
+    public ReadOnlyEntityList getTeamList() {
         return this.teamList;
     }
 
@@ -122,7 +122,7 @@ public class ModelManager implements Model {
      *
      * @return ReadableEntityList
      */
-    public ReadableEntityList getMentorList() {
+    public ReadOnlyEntityList getMentorList() {
         return this.mentorList;
     }
 

--- a/src/main/java/seedu/address/model/entitylist/EntityList.java
+++ b/src/main/java/seedu/address/model/entitylist/EntityList.java
@@ -9,7 +9,7 @@ import seedu.address.model.entity.Id;
  * This interface serves as the new API for the model.
  * Each child of {@code EntityList} should behave as a singleton.
  */
-public abstract class EntityList implements ReadableEntityList {
+public abstract class EntityList implements ReadOnlyEntityList {
     //    /**
     //     * Gets the entity from the entityList.
     //     *

--- a/src/main/java/seedu/address/model/entitylist/MentorList.java
+++ b/src/main/java/seedu/address/model/entitylist/MentorList.java
@@ -15,15 +15,15 @@ import seedu.address.model.entity.PrefixType;
  * {@code MentorList} should behave as a singleton.
  */
 public class MentorList extends EntityList {
+    private static int lastUsedId = 0;
+
     private List<Mentor> mentors;
-    private int lastUsedId;
 
     /**
      * Constructor.
      */
     public MentorList() {
         this.mentors = new ArrayList<>();
-        this.lastUsedId = 0;
     }
 
     /**
@@ -129,9 +129,17 @@ public class MentorList extends EntityList {
      *
      * @return ID
      */
-    @Override
-    public Id generateId() {
-        this.lastUsedId++;
-        return new Id(PrefixType.M, this.lastUsedId);
+    public static Id generateId() {
+        lastUsedId++;
+        return new Id(PrefixType.M, lastUsedId);
+    }
+
+    /**
+     * Sets the lastUsedId class attribute.
+     *
+     * @param number
+     */
+    public static void setLastUsedId(int number) {
+        lastUsedId = number;
     }
 }

--- a/src/main/java/seedu/address/model/entitylist/ParticipantList.java
+++ b/src/main/java/seedu/address/model/entitylist/ParticipantList.java
@@ -15,15 +15,15 @@ import seedu.address.model.entity.PrefixType;
  * {@code ParticipantList} should behave as a singleton.
  */
 public class ParticipantList extends EntityList {
+    private static int lastUsedId = 0;
+
     private List<Participant> participants;
-    private int lastUsedId;
 
     /**
      * Constructor.
      */
     public ParticipantList() {
         this.participants = new ArrayList<>();
-        this.lastUsedId = 0;
     }
 
     /**
@@ -140,9 +140,17 @@ public class ParticipantList extends EntityList {
      *
      * @return ID
      */
-    @Override
-    public Id generateId() {
-        this.lastUsedId++;
-        return new Id(PrefixType.P, this.lastUsedId);
+    public static Id generateId() {
+        lastUsedId++;
+        return new Id(PrefixType.P, lastUsedId);
+    }
+
+    /**
+     * Sets the lastUsedId class attribute.
+     *
+     * @param number
+     */
+    public static void setLastUsedId(int number) {
+        lastUsedId = number;
     }
 }

--- a/src/main/java/seedu/address/model/entitylist/ReadOnlyEntityList.java
+++ b/src/main/java/seedu/address/model/entitylist/ReadOnlyEntityList.java
@@ -8,7 +8,7 @@ import seedu.address.model.entity.Id;
 /**
  * Aims to make each EntityList readable.
  */
-public interface ReadableEntityList {
+public interface ReadOnlyEntityList {
     /**
      * Checks if a given entity list contains a certain entity.
      *
@@ -23,12 +23,4 @@ public interface ReadableEntityList {
      * @return List<? extends Entity>
      */
     List<? extends Entity> list();
-
-    /**
-     * This generates the id for the next entity object to be created.
-     *
-     * @return Id
-     */
-    Id generateId();
-
 }

--- a/src/main/java/seedu/address/model/entitylist/TeamList.java
+++ b/src/main/java/seedu/address/model/entitylist/TeamList.java
@@ -15,15 +15,15 @@ import seedu.address.model.entity.Team;
  * {@code TeamList} should behave as a singleton.
  */
 public class TeamList extends EntityList {
+    private static int lastUsedId = 0;
+
     private List<Team> teams;
-    private int lastUsedId;
 
     /**
      * Constructor.
      */
     public TeamList() {
         this.teams = new ArrayList<>();
-        this.lastUsedId = 0;
     }
 
     /**
@@ -129,9 +129,17 @@ public class TeamList extends EntityList {
      *
      * @return ID
      */
-    @Override
-    public Id generateId() {
-        this.lastUsedId++;
-        return new Id(PrefixType.T, this.lastUsedId);
+    public static Id generateId() {
+        lastUsedId++;
+        return new Id(PrefixType.T, lastUsedId);
+    }
+
+    /**
+     * Sets the lastUsedId class attribute.
+     *
+     * @param number
+     */
+    public static void setLastUsedId(int number) {
+        lastUsedId = number;
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -47,7 +47,7 @@ public class LogicManagerTest {
                 new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
-        logic = new LogicManager(model, storage);
+        logic = new LogicManager(model);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class LogicManagerTest {
         JsonUserPrefsStorage userPrefsStorage =
                 new JsonUserPrefsStorage(temporaryFolder.resolve("ioExceptionUserPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
-        logic = new LogicManager(model, storage);
+        logic = new LogicManager(model);
 
         // Execute add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -1,11 +1,23 @@
 package seedu.address.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
+
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.entity.Id;
 import seedu.address.model.entity.Participant;
@@ -16,16 +28,6 @@ import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.TypicalMentors;
 import seedu.address.testutil.TypicalParticipants;
 import seedu.address.testutil.TypicalTeams;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.BENSON;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ModelManagerTest {

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -1,33 +1,36 @@
 package seedu.address.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.BENSON;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.exceptions.AlfredException;
 import seedu.address.model.entity.Id;
 import seedu.address.model.entity.Participant;
 import seedu.address.model.entity.PrefixType;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.storage.AlfredStorage;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.TypicalMentors;
 import seedu.address.testutil.TypicalParticipants;
 import seedu.address.testutil.TypicalTeams;
 
-public class ModelManagerTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 
-    private ModelManager modelManager = new ModelManager();
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ModelManagerTest {
+    private AlfredStorage storage = mock(AlfredStorage.class);
+    private ModelManager modelManager = new ModelManager(storage, new UserPrefs());
 
     @Test
     public void constructor() {
@@ -103,11 +106,14 @@ public class ModelManagerTest {
     @Test
     public void addAndGetParticipant_validId_returnsParticipant() {
         try {
+            Mockito.doNothing().when(storage).saveParticipantList(any());
+            Mockito.doNothing().when(storage).saveTeamList(any());
+            Mockito.doNothing().when(storage).saveMentorList(any());
             modelManager = new ModelManager();
             modelManager.addParticipant(TypicalParticipants.A);
             Participant participant = modelManager.getParticipant(new Id(PrefixType.P, 1));
             assertTrue(participant.equals(TypicalParticipants.A));
-        } catch (AlfredException e) {
+        } catch (Exception e) {
             // do nothing
         }
     }
@@ -115,13 +121,16 @@ public class ModelManagerTest {
     @Test
     public void deleteParticipant_validId_returnsParticipant() {
         try {
+            Mockito.doNothing().when(storage).saveParticipantList(any());
+            Mockito.doNothing().when(storage).saveTeamList(any());
+            Mockito.doNothing().when(storage).saveMentorList(any());
             modelManager = new ModelManager();
             modelManager.addParticipant(TypicalParticipants.A);
             TypicalTeams.clearTeamA();
             modelManager.addTeam(TypicalTeams.A);
             Participant participant = modelManager.deleteParticipant(new Id(PrefixType.P, 1));
             assertTrue(participant.equals(TypicalParticipants.A));
-        } catch (AlfredException e) {
+        } catch (Exception e) {
             // do nothing
         }
     }
@@ -129,6 +138,9 @@ public class ModelManagerTest {
     @Test
     public void updateParticipant_validId_returnsTrue() {
         try {
+            Mockito.doNothing().when(storage).saveParticipantList(any());
+            Mockito.doNothing().when(storage).saveTeamList(any());
+            Mockito.doNothing().when(storage).saveMentorList(any());
             modelManager = new ModelManager();
             modelManager.addParticipant(TypicalParticipants.A);
             TypicalTeams.clearTeamA();
@@ -137,7 +149,7 @@ public class ModelManagerTest {
                     TypicalParticipants.A_UPDATED);
             assertTrue(TypicalTeams.A.getParticipants().get(0)
                     .equals(TypicalParticipants.A_UPDATED));
-        } catch (AlfredException e) {
+        } catch (Exception e) {
             // do nothing
         }
     }
@@ -145,12 +157,15 @@ public class ModelManagerTest {
     @Test
     public void getTeamByParticipantId_validId_returnsTeam() {
         try {
+            Mockito.doNothing().when(storage).saveParticipantList(any());
+            Mockito.doNothing().when(storage).saveTeamList(any());
+            Mockito.doNothing().when(storage).saveMentorList(any());
             modelManager = new ModelManager();
             TypicalTeams.clearTeamA();
             modelManager.addTeam(TypicalTeams.A);
             assertTrue(TypicalTeams.A
                     .equals(modelManager.getTeamByParticipantId(new Id(PrefixType.P, 1))));
-        } catch (AlfredException e) {
+        } catch (Exception e) {
             // do nothing
         }
     }
@@ -158,12 +173,15 @@ public class ModelManagerTest {
     @Test
     public void getTeamByMentorId_validId_returnsMentor() {
         try {
+            Mockito.doNothing().when(storage).saveParticipantList(any());
+            Mockito.doNothing().when(storage).saveTeamList(any());
+            Mockito.doNothing().when(storage).saveMentorList(any());
             modelManager = new ModelManager();
             TypicalTeams.clearTeamA();
             modelManager.addTeam(TypicalTeams.A);
             assertTrue(TypicalTeams.A
                     .equals(modelManager.getTeamByMentorId(new Id(PrefixType.M, 3))));
-        } catch (AlfredException e) {
+        } catch (Exception e) {
             // do nothing
         }
     }
@@ -171,6 +189,9 @@ public class ModelManagerTest {
     @Test
     public void updateMentor_validMentor_updatesMentor() {
         try {
+            Mockito.doNothing().when(storage).saveParticipantList(any());
+            Mockito.doNothing().when(storage).saveTeamList(any());
+            Mockito.doNothing().when(storage).saveMentorList(any());
             modelManager = new ModelManager();
             TypicalTeams.clearTeamA();
             modelManager.addTeam(TypicalTeams.A);
@@ -180,7 +201,7 @@ public class ModelManagerTest {
             assertTrue(modelManager.getTeamByMentorId(new Id(PrefixType.M, 3))
                     .equals(TypicalTeams.A));
 
-        } catch (AlfredException e) {
+        } catch (Exception e) {
             // do nothing
         }
     }
@@ -188,6 +209,9 @@ public class ModelManagerTest {
     @Test
     public void addParticipantToTeam_validParticipant_addsParticipant() {
         try {
+            Mockito.doNothing().when(storage).saveParticipantList(any());
+            Mockito.doNothing().when(storage).saveTeamList(any());
+            Mockito.doNothing().when(storage).saveMentorList(any());
             modelManager = new ModelManager();
             TypicalTeams.clearTeamA();
             modelManager.addTeam(TypicalTeams.A);
@@ -195,7 +219,7 @@ public class ModelManagerTest {
                     TypicalParticipants.B);
             assertTrue(modelManager.getTeam(new Id(PrefixType.T, 1))
                     .getParticipants().size() == 2);
-        } catch (AlfredException e) {
+        } catch (Exception e) {
             // do nothing
         }
     }


### PR DESCRIPTION
## Description
<!--
Describe the pull request and what it does
1. What is this implementing
2. How is it being implemented
3. Why is this being implemented
-->
This PR makes generateId a static method so that it can be called from Parser.
Also, I have decided to make Storage an attribute of ModelManager. Reason being that since Model is now the only component that interfaces with Storage, it is pretty much useless to keep storage in `Logic Manager`. Let me know if you folks disagree.

## Checks
- [x] No errors when running the tests
- [x] Build and checkstyle passes
- [] Run the app and ran 2 commands without failing
- [] Written the baseline test cases for the PR

## Changelog
- Changed the various EntityLists
- Changed MainApp and ModelManager
- Remove Storage from LogicManager

## Comments for Reviewer (if any)
@brianyenna this should be okay right