### PR TITLE
Implement redo

### DIFF
--- a/src/main/java/seedu/address/logic/commands/historycommand/HistoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/historycommand/HistoryCommand.java
@@ -1,6 +1,5 @@
-package seedu.address.logic.commands.undocommand;
+package seedu.address.logic.commands.historycommand;
 
-import seedu.address.commons.exceptions.AlfredModelHistoryException;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -10,10 +9,12 @@ import seedu.address.model.entity.CommandType;
 /**
  * Command that undoes the effects of the previous command, returning the model to its previous state.
  */
-public class UndoCommand extends Command {
-    public static final String COMMAND_WORD = "undo";
-    public static final String MESSAGE_SUCCESS = "Undid 1 command";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undoes the previous command";
+public class HistoryCommand extends Command {
+    public static final String COMMAND_WORD = "history";
+    public static final String MESSAGE_SUCCESS = "History shown";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the history of previously-executed commands"
+                                                            + "that are undo-able and redo-able";
+    public static final String MESSAGE_SHOW_HISTORY = "Showing the history of your commands.";
 
     /**
      * Executes the command and returns a CommandResult with a message.
@@ -22,11 +23,6 @@ public class UndoCommand extends Command {
      * @throws CommandException
      */
     public CommandResult execute(Model model) throws CommandException {
-        try {
-            model.undo();
-            return new CommandResult(String.format(MESSAGE_SUCCESS), CommandType.H);
-        } catch (AlfredModelHistoryException e) {
-            throw new CommandException(e.getMessage());
-        }
+        return new CommandResult(MESSAGE_SHOW_HISTORY, CommandType.H);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/historycommand/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/historycommand/RedoCommand.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.commands.historycommand;
+
+import seedu.address.commons.exceptions.AlfredModelHistoryException;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entity.CommandType;
+
+/**
+ * Command that redoes the effects of the previous command, returning the model to the state after re-doing the command.
+ */
+public class RedoCommand extends Command {
+    public static final String COMMAND_WORD = "redo";
+    public static final String MESSAGE_SUCCESS = "Re-did 1 command";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Redoes the previous command";
+
+    /**
+     * Executes the command and returns a CommandResult with a message.
+     * @param model contains the state of the data in memory.
+     * @return feedback message of the operation result for display.
+     * @throws CommandException
+     */
+    public CommandResult execute(Model model) throws CommandException {
+        try {
+            model.redo();
+            return new CommandResult(String.format(MESSAGE_SUCCESS), CommandType.H);
+        } catch (AlfredModelHistoryException e) {
+            throw new CommandException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/historycommand/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/historycommand/UndoCommand.java
@@ -1,5 +1,6 @@
-package seedu.address.logic.commands.undocommand;
+package seedu.address.logic.commands.historycommand;
 
+import seedu.address.commons.exceptions.AlfredModelHistoryException;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -9,12 +10,10 @@ import seedu.address.model.entity.CommandType;
 /**
  * Command that undoes the effects of the previous command, returning the model to its previous state.
  */
-public class HistoryCommand extends Command {
-    public static final String COMMAND_WORD = "history";
-    public static final String MESSAGE_SUCCESS = "History shown";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the history of previously-executed commands"
-                                                            + "that are undo-able and redo-able";
-    public static final String MESSAGE_SHOW_HISTORY = "Showing the history of your commands.";
+public class UndoCommand extends Command {
+    public static final String COMMAND_WORD = "undo";
+    public static final String MESSAGE_SUCCESS = "Un-did 1 command";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undoes the previous command";
 
     /**
      * Executes the command and returns a CommandResult with a message.
@@ -23,6 +22,11 @@ public class HistoryCommand extends Command {
      * @throws CommandException
      */
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult(MESSAGE_SHOW_HISTORY, CommandType.H);
+        try {
+            model.undo();
+            return new CommandResult(String.format(MESSAGE_SUCCESS), CommandType.H);
+        } catch (AlfredModelHistoryException e) {
+            throw new CommandException(e.getMessage());
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AlfredParser.java
+++ b/src/main/java/seedu/address/logic/parser/AlfredParser.java
@@ -17,9 +17,10 @@ import seedu.address.logic.commands.csvcommand.ExportCommand;
 import seedu.address.logic.commands.csvcommand.ImportCommand;
 import seedu.address.logic.commands.deletecommand.DeleteCommand;
 import seedu.address.logic.commands.findcommand.FindCommand;
+import seedu.address.logic.commands.historycommand.HistoryCommand;
+import seedu.address.logic.commands.historycommand.RedoCommand;
+import seedu.address.logic.commands.historycommand.UndoCommand;
 import seedu.address.logic.commands.listcommand.ListCommand;
-import seedu.address.logic.commands.undocommand.HistoryCommand;
-import seedu.address.logic.commands.undocommand.UndoCommand;
 import seedu.address.logic.commands.viewcommand.ViewCommand;
 import seedu.address.logic.parser.addcommandparser.AddCommandAllocator;
 import seedu.address.logic.parser.csvcommandparser.ExportCommandParser;
@@ -92,6 +93,9 @@ public class AlfredParser {
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();
 
         case HistoryCommand.COMMAND_WORD:
             return new HistoryCommand();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -207,6 +207,12 @@ public interface Model {
     void undo() throws AlfredModelHistoryException;
 
     /**
+     * Redoes the effects of the previously executed command and returns the model to the state
+     * after the execution of the command.
+     */
+    void redo() throws AlfredModelHistoryException;
+
+    /**
      * Gets a String detailing the previously executed commands that can be undone by the user.
      * @return String representing the previously executed commands that can be undone by the user.
      */

--- a/src/main/java/seedu/address/model/ModelHistoryManager.java
+++ b/src/main/java/seedu/address/model/ModelHistoryManager.java
@@ -230,8 +230,16 @@ public class ModelHistoryManager implements ModelHistory {
      * @throws AlfredModelHistoryException
      */
     public ModelHistoryRecord redo() throws AlfredModelHistoryException {
-        //TODO: Update this in v1.3-1.4
-        throw new AlfredModelHistoryException("Not yet implemented");
+        if (this.canRedo()) {
+            int currentIndex = this.history.indexOf(this.current);
+            this.current = this.history.get(currentIndex + 1);
+            ParticipantList.setLastUsedId(this.current.getParticipantListLastUsedId());
+            MentorList.setLastUsedId(this.current.getMentorListLastUsedId());
+            TeamList.setLastUsedId(this.current.getTeamListLastUsedId());
+            return this.current;
+        } else {
+            throw new AlfredModelHistoryException("Unable to redo any further!");
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -790,31 +790,52 @@ public class ModelManager implements Model {
     public void undo() throws AlfredModelHistoryException {
         if (this.history.canUndo()) {
             ModelHistoryRecord hr = this.history.undo();
-
-            //Set Last Used IDs for each of the EntityLists
-            ParticipantList.setLastUsedId(hr.getParticipantListLastUsedId());
-            MentorList.setLastUsedId(hr.getMentorListLastUsedId());
-            TeamList.setLastUsedId(hr.getTeamListLastUsedId());
-
-            //Update each of the EntityLists to the state in the ModelHistoryRecord hr
-            try {
-                this.participantList = hr.getParticipantList().copy();
-                this.mentorList = hr.getMentorList().copy();
-                this.teamList = hr.getTeamList().copy();
-            } catch (AlfredModelException e) {
-                throw new AlfredModelHistoryException("Unable to copy EntityLists from ModelHistoryRecord");
-            }
-
-            //Update each of the filteredEntityLists
-            this.filteredParticipantList =
-                    new FilteredList<>(this.participantList.getSpecificTypedList());
-            this.filteredMentorList =
-                    new FilteredList<>(this.mentorList.getSpecificTypedList());
-            this.filteredTeamList =
-                    new FilteredList<>(this.teamList.getSpecificTypedList());
+            updateModelState(hr);
         } else {
             throw new AlfredModelHistoryException("Unable to undo.");
         }
+    }
+
+    /**
+     * This method will return the ModelManager to the state where the previous command executed is redone.
+     * @throws AlfredModelHistoryException
+     */
+    public void redo() throws AlfredModelHistoryException {
+        if (this.history.canRedo()) {
+            ModelHistoryRecord hr = this.history.redo();
+            updateModelState(hr);
+        } else {
+            throw new AlfredModelHistoryException("Unable to redo.");
+        }
+    }
+
+    /**
+     * Updates the current Model state (for each of the EntityLists and their lastUsedIDs) using a ModelHistoryRecord.
+     * @param hr ModelHistoryRecord containing the state of each of the EntityLists and their lastUsedIDs.
+     * @throws AlfredModelHistoryException
+     */
+    private void updateModelState(ModelHistoryRecord hr) throws AlfredModelHistoryException {
+        //Set Last Used IDs for each of the EntityLists
+        ParticipantList.setLastUsedId(hr.getParticipantListLastUsedId());
+        MentorList.setLastUsedId(hr.getMentorListLastUsedId());
+        TeamList.setLastUsedId(hr.getTeamListLastUsedId());
+
+        //Update each of the EntityLists to the state in the ModelHistoryRecord hr
+        try {
+            this.participantList = hr.getParticipantList().copy();
+            this.mentorList = hr.getMentorList().copy();
+            this.teamList = hr.getTeamList().copy();
+        } catch (AlfredModelException e) {
+            throw new AlfredModelHistoryException("Unable to copy EntityLists from ModelHistoryRecord");
+        }
+
+        //Update each of the filteredEntityLists
+        this.filteredParticipantList =
+                new FilteredList<>(this.participantList.getSpecificTypedList());
+        this.filteredMentorList =
+                new FilteredList<>(this.mentorList.getSpecificTypedList());
+        this.filteredTeamList =
+                new FilteredList<>(this.teamList.getSpecificTypedList());
     }
 
     /**


### PR DESCRIPTION
## Description
Describe the pull request and what it does
1. What is this implementing
Implement redo feature, closes #174 

2. How is it being implemented
Implements a RedoCommand class, changes AlfredParser to recognise the command word, and implements logic within ModelHistoryManager to ensure that the redo command can only be executed when there are valid states to return to. 

3. Why is this being implemented
This is part of the v1.4 milestone. 


## Checks
- [X] No errors when running the tests
- [X] Build and checkstyle passes
- [X] Run the app and ran 2 commands without failing
- [] Written the baseline test cases for the PR

## Changelog
- []
- []
- []

## Comments for Reviewer (if any)
