### PR TITLE
Update undo redo tests

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -97,7 +97,6 @@ public class LogicManager implements Logic {
         return model.getMentorListFilePath();
     }
 
-
     @Override
     public GuiSettings getGuiSettings() {
         return model.getGuiSettings();

--- a/src/main/java/seedu/address/logic/commands/historycommand/HistoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/historycommand/HistoryCommand.java
@@ -11,10 +11,9 @@ import seedu.address.model.entity.CommandType;
  */
 public class HistoryCommand extends Command {
     public static final String COMMAND_WORD = "history";
-    public static final String MESSAGE_SUCCESS = "History shown";
+    public static final String MESSAGE_SUCCESS = "Showing the history of your commands: ";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the history of previously-executed commands"
                                                             + "that are undo-able and redo-able";
-    public static final String MESSAGE_SHOW_HISTORY = "Showing the history of your commands.";
 
     /**
      * Executes the command and returns a CommandResult with a message.
@@ -23,6 +22,6 @@ public class HistoryCommand extends Command {
      * @throws CommandException
      */
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult(MESSAGE_SHOW_HISTORY, CommandType.H);
+        return new CommandResult(MESSAGE_SUCCESS, CommandType.H);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/historycommand/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/historycommand/RedoCommand.java
@@ -24,7 +24,7 @@ public class RedoCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         try {
             model.redo();
-            return new CommandResult(String.format(MESSAGE_SUCCESS), CommandType.H);
+            return new CommandResult(MESSAGE_SUCCESS, CommandType.H);
         } catch (AlfredModelHistoryException e) {
             throw new CommandException(e.getMessage());
         }

--- a/src/main/java/seedu/address/logic/commands/historycommand/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/historycommand/UndoCommand.java
@@ -24,7 +24,7 @@ public class UndoCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         try {
             model.undo();
-            return new CommandResult(String.format(MESSAGE_SUCCESS), CommandType.H);
+            return new CommandResult(MESSAGE_SUCCESS, CommandType.H);
         } catch (AlfredModelHistoryException e) {
             throw new CommandException(e.getMessage());
         }

--- a/src/main/java/seedu/address/model/ModelHistoryManager.java
+++ b/src/main/java/seedu/address/model/ModelHistoryManager.java
@@ -119,9 +119,6 @@ public class ModelHistoryManager implements ModelHistory {
         if (this.canUndo()) {
             int currentIndex = this.history.indexOf(this.current); //Get prev state pointer index
             this.current = this.history.get(currentIndex - 1); //Update the current state pointer
-            ParticipantList.setLastUsedId(this.current.getParticipantListLastUsedId());
-            MentorList.setLastUsedId(this.current.getMentorListLastUsedId());
-            TeamList.setLastUsedId(this.current.getTeamListLastUsedId());
             return this.current;
         } else {
             throw new AlfredModelHistoryException("Unable to undo any further!");
@@ -233,9 +230,6 @@ public class ModelHistoryManager implements ModelHistory {
         if (this.canRedo()) {
             int currentIndex = this.history.indexOf(this.current);
             this.current = this.history.get(currentIndex + 1);
-            ParticipantList.setLastUsedId(this.current.getParticipantListLastUsedId());
-            MentorList.setLastUsedId(this.current.getMentorListLastUsedId());
-            TeamList.setLastUsedId(this.current.getTeamListLastUsedId());
             return this.current;
         } else {
             throw new AlfredModelHistoryException("Unable to redo any further!");

--- a/src/main/java/seedu/address/model/ModelHistoryManager.java
+++ b/src/main/java/seedu/address/model/ModelHistoryManager.java
@@ -80,7 +80,7 @@ public class ModelHistoryManager implements ModelHistory {
 
     /**
      * Adds a ModelHistoryRecord to command history. This method checks for capacity constraints of the
-     * ModelHisxtoryManager and is responsible for ensuring a valid sequence of commands in history for Undo/Redo.
+     * ModelHistoryManager and is responsible for ensuring a valid sequence of commands in history for Undo/Redo.
      * @param r
      */
     private void addToHistory(ModelHistoryRecord r) {

--- a/src/test/java/seedu/address/logic/commands/historycommand/HistoryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/historycommand/HistoryCommandTest.java
@@ -10,7 +10,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.entity.CommandType;
 import seedu.address.stub.ModelManagerStub;
 
-class RedoCommandTest {
+class HistoryCommandTest {
     private ModelManagerStub modelStub;
 
     @BeforeEach
@@ -20,9 +20,9 @@ class RedoCommandTest {
 
     @Test
     void execute_success() throws AlfredException {
-        CommandResult commandResult = new RedoCommand().execute(modelStub);
+        CommandResult commandResult = new HistoryCommand().execute(modelStub);
 
-        assertEquals(RedoCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        assertEquals(HistoryCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
         assertEquals(CommandType.H, commandResult.getCommandType());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/historycommand/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/historycommand/RedoCommandTest.java
@@ -1,0 +1,14 @@
+package seedu.address.logic.commands.historycommand;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RedoCommandTest {
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+    }
+
+    @org.junit.jupiter.api.Test
+    void execute() {
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/historycommand/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/historycommand/UndoCommandTest.java
@@ -10,7 +10,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.entity.CommandType;
 import seedu.address.stub.ModelManagerStub;
 
-class RedoCommandTest {
+class UndoCommandTest {
     private ModelManagerStub modelStub;
 
     @BeforeEach
@@ -20,9 +20,9 @@ class RedoCommandTest {
 
     @Test
     void execute_success() throws AlfredException {
-        CommandResult commandResult = new RedoCommand().execute(modelStub);
+        CommandResult commandResult = new UndoCommand().execute(modelStub);
 
-        assertEquals(RedoCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
+        assertEquals(UndoCommand.MESSAGE_SUCCESS, commandResult.getFeedbackToUser());
         assertEquals(CommandType.H, commandResult.getCommandType());
     }
 }

--- a/src/test/java/seedu/address/model/ModelHistoryManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelHistoryManagerTest.java
@@ -3,16 +3,12 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import jdk.jfr.StackTrace;
 import seedu.address.commons.exceptions.AlfredException;
-import seedu.address.commons.exceptions.AlfredModelException;
 import seedu.address.commons.exceptions.AlfredModelHistoryException;
-import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.logic.commands.addcommand.AddMentorCommand;
 import seedu.address.logic.commands.addcommand.AddParticipantCommand;
 import seedu.address.logic.commands.listcommand.ListParticipantCommand;

--- a/src/test/java/seedu/address/model/ModelHistoryManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelHistoryManagerTest.java
@@ -3,19 +3,27 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import jdk.jfr.StackTrace;
 import seedu.address.commons.exceptions.AlfredException;
+import seedu.address.commons.exceptions.AlfredModelException;
 import seedu.address.commons.exceptions.AlfredModelHistoryException;
+import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.logic.commands.addcommand.AddMentorCommand;
 import seedu.address.logic.commands.addcommand.AddParticipantCommand;
+import seedu.address.logic.commands.listcommand.ListParticipantCommand;
 import seedu.address.model.entity.Email;
 import seedu.address.model.entity.Id;
+import seedu.address.model.entity.Mentor;
 import seedu.address.model.entity.Name;
 import seedu.address.model.entity.Participant;
 import seedu.address.model.entity.Phone;
 import seedu.address.model.entity.PrefixType;
+import seedu.address.model.entity.SubjectName;
 import seedu.address.model.entitylist.MentorList;
 import seedu.address.model.entitylist.ParticipantList;
 import seedu.address.model.entitylist.TeamList;
@@ -29,6 +37,7 @@ class ModelHistoryManagerTest {
     private TeamList tList;
     private ModelHistoryManager hm;
     private Participant newP;
+    private Mentor newM;
 
     @BeforeEach
     void beforeEach() throws AlfredException {
@@ -45,56 +54,41 @@ class ModelHistoryManagerTest {
                                new Id(PrefixType.P, 123),
                                new Email("testperson@gmail.com"),
                                new Phone("93200000"));
+
+        newM = new Mentor(new Name("Test Mentor"),
+                          new Id(PrefixType.M, 10),
+                          new Phone("+6592222222"),
+                          new Email("testmentor@gmail.com"),
+                          new Name("Test Organization"),
+                          SubjectName.SOCIAL);
     }
 
     @Test
-    void updateHistory_changeToEntityList_success() throws AlfredModelHistoryException, AlfredException {
+    void updateHistory_isTrackableStateCommand() throws AlfredException {
         pList.add(newP);
         hm.updateHistory(pList, ParticipantList.getLastUsedId(),
                          mList, MentorList.getLastUsedId(),
                          tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
-        assertEquals(2, hm.getLengthOfHistory());
+        assertEquals(2, hm.getLengthOfHistory()); //ModelHistoryRecord with TrackableState Command added successfully.
         assertTrue(hm.canUndo());
     }
 
     @Test
-    void updateHistory_noEntityChange_success() throws AlfredModelHistoryException {
+    void updateHistory_notTrackableStateCommand() throws AlfredException {
         hm.updateHistory(pList, ParticipantList.getLastUsedId(),
                          mList, MentorList.getLastUsedId(),
-                         tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
-        assertEquals(2, hm.getLengthOfHistory());
-        assertTrue(hm.canUndo());
-    }
-
-    @Test
-    void canUndo_initialModelHistoryManager_false() {
+                         tList, TeamList.getLastUsedId(), new ListParticipantCommand());
+        assertEquals(1, hm.getLengthOfHistory());
         assertFalse(hm.canUndo());
     }
 
     @Test
-    void canUndo_entityChange_true() throws AlfredModelHistoryException {
-        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
-                         mList, MentorList.getLastUsedId(),
-                         tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
-        assertTrue(hm.canUndo());
-    }
-
-    @Test
-    void canRedo() {
-        //TODO: Update this in v1.3-1.4
-        assertFalse(hm.canRedo());
-    }
-
-    @Test
     void undo_testEqualityOfLists_success() throws AlfredException {
-        pList.add(newP);
-        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
+        ParticipantList newPList = pList.copy();
+        newPList.add(newP);
+        hm.updateHistory(newPList, ParticipantList.getLastUsedId(),
                          mList, MentorList.getLastUsedId(),
                          tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
-        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
-                         mList, MentorList.getLastUsedId(),
-                         tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
-
         assertTrue(hm.canUndo());
         ModelHistoryRecord hr = hm.undo();
         ParticipantList historyPList = hr.getParticipantList();
@@ -103,23 +97,100 @@ class ModelHistoryManagerTest {
 
     @Test
     void undo_testLastUsedIdSetting_success() throws AlfredModelHistoryException, AlfredException {
-        int lastUsedIdBefore = ParticipantList.getLastUsedId();
-        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
-                         mList, MentorList.getLastUsedId(),
-                         tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
         pList.add(newP);
         hm.updateHistory(pList, ParticipantList.getLastUsedId(),
                          mList, MentorList.getLastUsedId(),
                          tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
         ModelHistoryRecord hr = hm.undo();
-        assertEquals(lastUsedIdBefore, hr.getParticipantListLastUsedId());
         assertEquals(hr.getParticipantListLastUsedId(), ParticipantList.getLastUsedId());
     }
 
     @Test
-    void redo() {
-        //TODO: Update this in v1.3-1.4
-        assertTrue(true);
+    void canUndo_testUndoEndPoint() throws AlfredException {
+        pList.add(newP);
+        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
+                         mList, MentorList.getLastUsedId(),
+                         tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
+        assertTrue(hm.canUndo());
+        ModelHistoryRecord hr = hm.undo();
+        assertFalse(hm.canUndo());
+    }
+
+    @Test
+    void canUndo_initialModelHistoryManager_false() {
+        assertFalse(hm.canUndo());
+    }
+
+    @Test
+    void canRedo_testRedoEndPoint() throws AlfredException {
+        assertFalse(hm.canRedo());
+        pList.add(newP);
+        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
+                         mList, MentorList.getLastUsedId(),
+                         tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
+        assertFalse(hm.canRedo());
+        hm.undo();
+        assertTrue(hm.canRedo());
+        mList.add(newM);
+        //Overwrites the valid redo-able commands, so canRedo() should return false.
+        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
+                         mList, MentorList.getLastUsedId(),
+                         tList, TeamList.getLastUsedId(), new AddMentorCommand(newM));
+        assertFalse(hm.canRedo());
+    }
+
+    @Test
+    void redo_testEqualityOfLists_success() throws AlfredException {
+        pList.add(newP);
+        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
+                         mList, MentorList.getLastUsedId(),
+                         tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
+        ModelHistoryRecord hr = hm.undo();
+        hr = hm.redo();
+        assertEquals(pList.getSpecificTypedList(), hr.getParticipantList().getSpecificTypedList());
+    }
+
+    @Test
+    void redo_testLastUsedIdSetting_success() throws AlfredException {
+        pList.add(newP);
+        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
+                         mList, MentorList.getLastUsedId(),
+                         tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
+        ModelHistoryRecord hr = hm.undo();
+        hr = hm.redo();
+        assertEquals(pList.getLastUsedId(), hr.getParticipantListLastUsedId());
+    }
+
+    @Test
+    void canRedo_initialModelHistoryManager_false() {
+        assertFalse(hm.canRedo());
+    }
+
+    @Test
+    void getCommandHistory_initial() {
+        assertEquals(hm.getCommandHistory().size(), 3);
+        assertEquals(hm.getCommandHistory().get(0).getCommandType(), CommandRecord.CommandType.END);
+        assertEquals(hm.getCommandHistory().get(1).getCommandType(), CommandRecord.CommandType.CURR);
+        assertEquals(hm.getCommandHistory().get(2).getCommandType(), CommandRecord.CommandType.END);
+    }
+
+    @Test
+    void getCommandHistory_withUndoRedo() throws AlfredException {
+        pList.add(newP);
+        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
+                mList, MentorList.getLastUsedId(),
+                tList, TeamList.getLastUsedId(), new AddParticipantCommand(newP));
+        mList.add(newM);
+        hm.updateHistory(pList, ParticipantList.getLastUsedId(),
+                         mList, MentorList.getLastUsedId(),
+                         tList, TeamList.getLastUsedId(), new AddMentorCommand(newM));
+        hm.undo();
+        assertEquals(hm.getCommandHistory().size(), 5);
+        assertEquals(hm.getCommandHistory().get(0).getCommandType(), CommandRecord.CommandType.END);
+        assertEquals(hm.getCommandHistory().get(1).getCommandType(), CommandRecord.CommandType.REDO);
+        assertEquals(hm.getCommandHistory().get(2).getCommandType(), CommandRecord.CommandType.CURR);
+        assertEquals(hm.getCommandHistory().get(3).getCommandType(), CommandRecord.CommandType.UNDO);
+        assertEquals(hm.getCommandHistory().get(4).getCommandType(), CommandRecord.CommandType.END);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelHistoryRecordTest.java
+++ b/src/test/java/seedu/address/model/ModelHistoryRecordTest.java
@@ -1,0 +1,101 @@
+package seedu.address.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.AlfredException;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.addcommand.AddParticipantCommand;
+import seedu.address.model.entity.Email;
+import seedu.address.model.entity.Id;
+import seedu.address.model.entity.Mentor;
+import seedu.address.model.entity.Name;
+import seedu.address.model.entity.Participant;
+import seedu.address.model.entity.Phone;
+import seedu.address.model.entity.PrefixType;
+import seedu.address.model.entity.Team;
+import seedu.address.model.entitylist.MentorList;
+import seedu.address.model.entitylist.ParticipantList;
+import seedu.address.model.entitylist.TeamList;
+import seedu.address.testutil.TypicalMentors;
+import seedu.address.testutil.TypicalParticipants;
+import seedu.address.testutil.TypicalTeams;
+
+class ModelHistoryRecordTest {
+    private ModelHistoryRecord hr;
+    private ParticipantList pList;
+    int pListId;
+    private MentorList mList;
+    int mListId;
+    private TeamList tList;
+    int tListId;
+    private Participant newP;
+    private Command c;
+
+    @BeforeEach
+    void setUp() throws AlfredException {
+        pListId = 1;
+        pList = TypicalParticipants.getTypicalParticipantList();
+        ParticipantList.setLastUsedId(pListId);
+
+        mListId = 2;
+        mList = TypicalMentors.getTypicalMentorList();
+        MentorList.setLastUsedId(mListId);
+
+        tListId = 3;
+        tList = TypicalTeams.getTypicalTeamList();
+        TeamList.setLastUsedId(tListId);
+
+        newP = new Participant(new Name("Test Person"),
+                               new Id(PrefixType.P, 123),
+                               new Email("testperson@gmail.com"),
+                               new Phone("93200000"));
+        Command c = new AddParticipantCommand(newP);
+        hr = new ModelHistoryRecord(pList, pListId,
+                                    mList, mListId,
+                                    tList, tListId,
+                                    c);
+    }
+
+    @Test
+    void getParticipantList_checkDeepCopy() {
+        assertTrue(hr.getParticipantList() != pList);
+        List<Participant> copiedPList = hr.getParticipantList().getSpecificTypedList();
+        List<Participant> origPList = pList.getSpecificTypedList();
+        for (int i = 0; i < copiedPList.size(); i++) {
+            Participant copiedParticipant = copiedPList.get(i);
+            Participant origParticipant = origPList.get(i);
+            assertTrue(copiedParticipant != origParticipant);
+        }
+    }
+
+    @Test
+    void getMentorList_checkDeepCopy() {
+        assertTrue(hr.getMentorList() != mList);
+        List<Mentor> copiedMList = hr.getMentorList().getSpecificTypedList();
+        List<Mentor> origMList = mList.getSpecificTypedList();
+        for (int i = 0; i < copiedMList.size(); i++) {
+            Mentor copiedMentor = copiedMList.get(i);
+            Mentor origMentor = origMList.get(i);
+            assertTrue(copiedMentor != origMentor);
+        }
+    }
+
+    @Test
+    void getTeamList_checkDeepCopy() {
+        assertTrue(hr.getTeamList() != tList);
+        List<Team> copiedTList = hr.getTeamList().getSpecificTypedList();
+        List<Team> origTList = tList.getSpecificTypedList();
+        for (int i = 0; i < copiedTList.size(); i++) {
+            Team copiedTeam = copiedTList.get(i);
+            Team origTeam = origTList.get(i);
+            assertTrue(copiedTeam != origTeam);
+        }
+    }
+}

--- a/src/test/java/seedu/address/model/ModelHistoryRecordTest.java
+++ b/src/test/java/seedu/address/model/ModelHistoryRecordTest.java
@@ -28,11 +28,11 @@ import seedu.address.testutil.TypicalTeams;
 class ModelHistoryRecordTest {
     private ModelHistoryRecord hr;
     private ParticipantList pList;
-    int pListId;
+    private int pListId;
     private MentorList mList;
-    int mListId;
+    private int mListId;
     private TeamList tList;
-    int tListId;
+    private int tListId;
     private Participant newP;
     private Command c;
 

--- a/src/test/java/seedu/address/model/ModelHistoryRecordTest.java
+++ b/src/test/java/seedu/address/model/ModelHistoryRecordTest.java
@@ -1,7 +1,5 @@
 package seedu.address.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -72,6 +70,10 @@ class ModelHistoryRecordTest {
             Participant copiedParticipant = copiedPList.get(i);
             Participant origParticipant = origPList.get(i);
             assertTrue(copiedParticipant != origParticipant);
+            assertTrue(copiedParticipant.getEmail() != origParticipant.getEmail());
+            assertTrue(copiedParticipant.getPhone() != origParticipant.getPhone());
+            assertTrue(copiedParticipant.getId() != origParticipant.getId());
+            assertTrue(copiedParticipant.getName() != origParticipant.getName());
         }
     }
 
@@ -84,6 +86,12 @@ class ModelHistoryRecordTest {
             Mentor copiedMentor = copiedMList.get(i);
             Mentor origMentor = origMList.get(i);
             assertTrue(copiedMentor != origMentor);
+            assertTrue(copiedMentor.getName() != origMentor.getName());
+            assertTrue(copiedMentor.getId() != origMentor.getId());
+            assertTrue(copiedMentor.getPhone() != origMentor.getPhone());
+            assertTrue(copiedMentor.getEmail() != origMentor.getEmail());
+            assertTrue(copiedMentor.getOrganization() != origMentor.getOrganization());
+            assertTrue(copiedMentor.getSubject() == origMentor.getSubject()); //Subject is an Enum
         }
     }
 
@@ -96,6 +104,14 @@ class ModelHistoryRecordTest {
             Team copiedTeam = copiedTList.get(i);
             Team origTeam = origTList.get(i);
             assertTrue(copiedTeam != origTeam);
+            assertTrue(copiedTeam.getId() != origTeam.getId());
+            assertTrue(copiedTeam.getName() != origTeam.getName());
+            assertTrue(copiedTeam.getParticipants() != origTeam.getParticipants());
+            assertTrue(copiedTeam.getMentor() != origTeam.getMentor());
+            assertTrue(copiedTeam.getSubject() == origTeam.getSubject()); //Subject is an Enum
+            assertTrue(copiedTeam.getScore() != origTeam.getScore());
+            assertTrue(copiedTeam.getProjectName() != origTeam.getProjectName());
+            assertTrue(copiedTeam.getLocation() != origTeam.getLocation());
         }
     }
 }

--- a/src/test/java/seedu/address/stub/ModelManagerStub.java
+++ b/src/test/java/seedu/address/stub/ModelManagerStub.java
@@ -255,7 +255,20 @@ public class ModelManagerStub extends ModelManager {
      */
     @Override
     public void updateHistory(Command c) {
+    }
 
+    /**
+     * Placeholder method simulating the undoing of a command in ModelHistory
+     */
+    @Override
+    public void undo() {
+    }
+
+    /**
+     * Placeholder method simulating the redoing of a command in ModelHistory
+     */
+    @Override
+    public void redo() {
     }
 
     /**


### PR DESCRIPTION
## Description
Describe the pull request and what it does
1. What is this implementing
Closes #177, by creating tests for Undo/Redo/History Commands
Closes #176, by checking that a deep copy of the lists are generated each time a new ModelHistoryRecord object is instantiated.
Closes #141, by creating new tests for the latest changes in ModelHistoryManager. 

2. How is it being implemented
See above.

3. Why is this being implemented
Ensure that the individual classes are performing according to their specification. 

## Checks
- [X] No errors when running the tests
- [X] Build and checkstyle passes
- [X] Run the app and ran 2 commands without failing
- [X] Written the baseline test cases for the PR

## Changelog
- []
- []
- []

## Comments for Reviewer (if any)
