### PR TITLE
Implement negative find and find by union

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ src/test/data/sandbox/
 
 # Binaries
 bin/
+
+# Export files
+AlfredData/

--- a/src/main/java/seedu/address/commons/Predicates.java
+++ b/src/main/java/seedu/address/commons/Predicates.java
@@ -25,8 +25,10 @@ public class Predicates {
                 : (team) -> team.getName().toString().contains(name);
     }
 
-    public static Predicate<Mentor> getPredicateFindMentorByName(String name) {
-        return (mentor) -> mentor.getName().toString().contains(name);
+    public static Predicate<Mentor> getPredicateFindMentorByName(String name, boolean neg) {
+        return neg
+                ? (mentor) -> !mentor.getName().toString().contains(name)
+                : (mentor) -> mentor.getName().toString().contains(name);
     }
 
     public static Predicate<Team> getPredicateFindTeamByProjectName(String name, boolean neg) {
@@ -41,8 +43,10 @@ public class Predicates {
                 : (participant) -> participant.getEmail().toString().contains(email);
     }
 
-    public static Predicate<Mentor> getPredicateFindMentorByEmail(String email) {
-        return (mentor) -> mentor.getEmail().toString().contains(email);
+    public static Predicate<Mentor> getPredicateFindMentorByEmail(String email, boolean neg) {
+        return neg
+                ? (mentor) -> !mentor.getEmail().toString().contains(email)
+                : (mentor) -> mentor.getEmail().toString().contains(email);
     }
 
     public static Predicate<Participant> getPredicateFindParticipantByPhone(String phone, boolean neg) {
@@ -51,12 +55,16 @@ public class Predicates {
                 : (participant) -> participant.getPhone().toString().contains(phone);
     }
 
-    public static Predicate<Mentor> getPredicateFindMentorByPhone(String phone) {
-        return (mentor) -> mentor.getPhone().toString().contains(phone);
+    public static Predicate<Mentor> getPredicateFindMentorByPhone(String phone, boolean neg) {
+        return neg
+                ? (mentor) -> !mentor.getPhone().toString().contains(phone)
+                : (mentor) -> mentor.getPhone().toString().contains(phone);
     }
 
-    public static Predicate<Mentor> getPredicateFindMentorByOrganization(String org) {
-        return (mentor) -> mentor.getOrganization().toString().contains(org);
+    public static Predicate<Mentor> getPredicateFindMentorByOrganization(String org, boolean neg) {
+        return neg
+                ? (mentor) -> !mentor.getOrganization().toString().contains(org)
+                : (mentor) -> mentor.getOrganization().toString().contains(org);
     }
 
     public static <T> Predicate<T> predicateReducer(List<Predicate<T>> predicates) {

--- a/src/main/java/seedu/address/commons/Predicates.java
+++ b/src/main/java/seedu/address/commons/Predicates.java
@@ -13,32 +13,42 @@ import seedu.address.model.entity.Team;
  * by the find command.
  */
 public class Predicates {
-    public static Predicate<Participant> getPredicateFindParticipantByName(String name) {
-        return (participant) -> participant.getName().toString().contains(name);
+    public static Predicate<Participant> getPredicateFindParticipantByName(String name, boolean neg) {
+        return neg
+                ? (participant) -> !participant.getName().toString().contains(name)
+                : (participant) -> participant.getName().toString().contains(name);
     }
 
-    public static Predicate<Team> getPredicateFindTeamByName(String name) {
-        return (team) -> team.getName().toString().contains(name);
+    public static Predicate<Team> getPredicateFindTeamByName(String name, boolean neg) {
+        return neg
+                ? (team) -> !team.getName().toString().contains(name)
+                : (team) -> team.getName().toString().contains(name);
     }
 
     public static Predicate<Mentor> getPredicateFindMentorByName(String name) {
         return (mentor) -> mentor.getName().toString().contains(name);
     }
 
-    public static Predicate<Team> getPredicateFindTeamByProjectName(String name) {
-        return (team) -> team.getName().toString().contains(name);
+    public static Predicate<Team> getPredicateFindTeamByProjectName(String name, boolean neg) {
+        return neg
+                ? (team) -> !team.getProjectName().toString().contains(name)
+                : (team) -> team.getProjectName().toString().contains(name);
     }
 
-    public static Predicate<Participant> getPredicateFindParticipantByEmail(String email) {
-        return (participant) -> participant.getEmail().toString().contains(email);
+    public static Predicate<Participant> getPredicateFindParticipantByEmail(String email, boolean neg) {
+        return neg
+                ? (participant) -> !participant.getEmail().toString().contains(email)
+                : (participant) -> participant.getEmail().toString().contains(email);
     }
 
     public static Predicate<Mentor> getPredicateFindMentorByEmail(String email) {
         return (mentor) -> mentor.getEmail().toString().contains(email);
     }
 
-    public static Predicate<Participant> getPredicateFindParticipantByPhone(String phone) {
-        return (participant) -> participant.getPhone().toString().contains(phone);
+    public static Predicate<Participant> getPredicateFindParticipantByPhone(String phone, boolean neg) {
+        return neg
+                ? (participant) -> !participant.getPhone().toString().contains(phone)
+                : (participant) -> participant.getPhone().toString().contains(phone);
     }
 
     public static Predicate<Mentor> getPredicateFindMentorByPhone(String phone) {
@@ -51,6 +61,10 @@ public class Predicates {
 
     public static <T> Predicate<T> predicateReducer(List<Predicate<T>> predicates) {
         return predicates.stream().reduce(predicate -> true, Predicate::and);
+    }
+
+    public static <T> Predicate<T> predicateReducerOr(List<Predicate<T>> predicates) {
+        return predicates.stream().reduce(predicate -> false, Predicate::or);
     }
 
     public static Predicate<Entity> viewSpecifiedEntity(Entity entityToView) {

--- a/src/main/java/seedu/address/logic/commands/findcommand/FindMentorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/findcommand/FindMentorCommand.java
@@ -10,6 +10,7 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.Predicates;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.parser.findcommandparser.FindCommandUtilEnum;
 import seedu.address.model.Model;
 import seedu.address.model.entity.CommandType;
 import seedu.address.model.entity.Mentor;
@@ -26,41 +27,71 @@ public class FindMentorCommand extends FindCommand {
             + "Example: " + COMMAND_WORD + " n/John Doe";
     public static final String MESSAGE_SUCCESS = "Successfully ran the find command.";
 
-    private String name;
-    private String email;
-    private String phone;
-    private String organization;
+    private String nameNorm;
+    private String emailNorm;
+    private String phoneNorm;
+    private String organizationNorm;
+    private String nameExclude;
+    private String emailExcude;
+    private String phoneExclude;
+    private String organizationExclude;
     private Predicate<Mentor> findPredicate;
 
     public FindMentorCommand(
-            Optional<String> name,
-            Optional<String> email,
-            Optional<String> phone,
-            Optional<String> organization
+            FindCommandUtilEnum type,
+            Optional<String> nameNorm,
+            Optional<String> emailNorm,
+            Optional<String> phoneNorm,
+            Optional<String> organizationNorm,
+            Optional<String> nameExclude,
+            Optional<String> emailExclude,
+            Optional<String> phoneExclude,
+            Optional<String> organizationExclude
     ) {
         List<Predicate<Mentor>> filterPredicates = new ArrayList<>();
-        if (name.isPresent()) {
-            filterPredicates.add(Predicates.getPredicateFindMentorByName(name.get()));
+        if (nameNorm.isPresent()) {
+            filterPredicates.add(Predicates.getPredicateFindMentorByName(nameNorm.get(), false));
         }
 
-        if (phone.isPresent()) {
-            filterPredicates.add(Predicates.getPredicateFindMentorByPhone(phone.get()));
+        if (phoneNorm.isPresent()) {
+            filterPredicates.add(Predicates.getPredicateFindMentorByPhone(phoneNorm.get(), false));
         }
 
-        if (email.isPresent()) {
-            filterPredicates.add(Predicates.getPredicateFindMentorByEmail(email.get()));
+        if (emailNorm.isPresent()) {
+            filterPredicates.add(Predicates.getPredicateFindMentorByEmail(emailNorm.get(), false));
         }
 
-        if (organization.isPresent()) {
+        if (organizationNorm.isPresent()) {
             filterPredicates.add(
-                    Predicates.getPredicateFindMentorByOrganization(organization.get()));
+                    Predicates.getPredicateFindMentorByOrganization(organizationNorm.get(), false));
+        }
+
+        if (nameExclude.isPresent()) {
+            filterPredicates.add(Predicates.getPredicateFindMentorByName(nameExclude.get(), true));
+        }
+
+        if (phoneExclude.isPresent()) {
+            filterPredicates.add(Predicates.getPredicateFindMentorByPhone(phoneExclude.get(), true));
+        }
+
+        if (emailExclude.isPresent()) {
+            filterPredicates.add(Predicates.getPredicateFindMentorByEmail(emailExclude.get(), true));
+        }
+
+        if (organizationExclude.isPresent()) {
+            filterPredicates.add(
+                    Predicates.getPredicateFindMentorByOrganization(organizationExclude.get(), true));
         }
 
         this.findPredicate = Predicates.predicateReducer(filterPredicates);
-        this.name = name.orElse("");
-        this.email = email.orElse("");
-        this.phone = phone.orElse("");
-        this.organization = organization.orElse("");
+        this.nameNorm = nameNorm.orElse("");
+        this.emailNorm = emailNorm.orElse("");
+        this.phoneNorm = phoneNorm.orElse("");
+        this.organizationNorm = organizationNorm.orElse("");
+        this.nameExclude = nameExclude.orElse("");
+        this.emailExcude = emailExclude.orElse("");
+        this.phoneExclude = phoneExclude.orElse("");
+        this.organizationExclude = organizationExclude.orElse("");
     }
 
     @Override
@@ -84,9 +115,13 @@ public class FindMentorCommand extends FindCommand {
             return false;
         }
 
-        return name.equals(((FindMentorCommand) otherFindCommand).name)
-                && email.equals(((FindMentorCommand) otherFindCommand).email)
-                && phone.equals(((FindMentorCommand) otherFindCommand).phone)
-                && organization.equals(((FindMentorCommand) otherFindCommand).organization);
+        return nameNorm.equals(((FindMentorCommand) otherFindCommand).nameNorm)
+                && emailNorm.equals(((FindMentorCommand) otherFindCommand).emailNorm)
+                && phoneNorm.equals(((FindMentorCommand) otherFindCommand).phoneNorm)
+                && organizationNorm.equals(((FindMentorCommand) otherFindCommand).organizationNorm)
+                && nameExclude.equals(((FindMentorCommand) otherFindCommand).nameExclude)
+                && emailExcude.equals(((FindMentorCommand) otherFindCommand).emailExcude)
+                && phoneExclude.equals(((FindMentorCommand) otherFindCommand).phoneExclude)
+                && organizationExclude.equals(((FindMentorCommand) otherFindCommand).organizationExclude);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/findcommand/FindParticipantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/findcommand/FindParticipantCommand.java
@@ -10,6 +10,7 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.Predicates;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.parser.findcommandparser.FindCommandUtilEnum;
 import seedu.address.model.Model;
 import seedu.address.model.entity.CommandType;
 import seedu.address.model.entity.Participant;
@@ -26,37 +27,65 @@ public class FindParticipantCommand extends FindCommand {
             + "Example: " + COMMAND_WORD + " n/John Doe";
     public static final String MESSAGE_SUCCESS = "Successfully ran the find command.";
 
-    private String name;
-    private String email;
-    private String phone;
+    private String nameNorm;
+    private String emailNorm;
+    private String phoneNorm;
+    private String nameExclude;
+    private String emailExclude;
+    private String phoneExclude;
     private Predicate<Participant> findPredicate;
 
     public FindParticipantCommand(
-            Optional<String> name,
-            Optional<String> email,
-            Optional<String> phone
+            FindCommandUtilEnum type,
+            Optional<String> nameNorm,
+            Optional<String> emailNorm,
+            Optional<String> phoneNorm,
+            Optional<String> nameExclude,
+            Optional<String> emailExclude,
+            Optional<String> phoneExclude
     ) {
         List<Predicate<Participant>> filterPredicates = new ArrayList<>();
-        if (name.isPresent()) {
+        if (nameNorm.isPresent()) {
             filterPredicates.add(
-                    Predicates.getPredicateFindParticipantByName(name.get()));
+                    Predicates.getPredicateFindParticipantByName(nameNorm.get(), false));
         }
 
-        if (email.isPresent()) {
+        if (emailNorm.isPresent()) {
             filterPredicates.add(
-                    Predicates.getPredicateFindParticipantByEmail(email.get()));
+                    Predicates.getPredicateFindParticipantByEmail(emailNorm.get(), false));
         }
 
-        if (phone.isPresent()) {
+        if (phoneNorm.isPresent()) {
             filterPredicates.add(
-                    Predicates.getPredicateFindParticipantByPhone(phone.get()));
+                    Predicates.getPredicateFindParticipantByPhone(phoneNorm.get(), false));
         }
 
-        this.findPredicate = Predicates.predicateReducer(filterPredicates);
-        this.name = name.orElse("");
-        this.email = email.orElse("");
-        this.phone = email.orElse("");
-        this.phone = email.orElse("");
+        if (nameExclude.isPresent()) {
+            filterPredicates.add(
+                    Predicates.getPredicateFindParticipantByName(nameNorm.get(), true));
+        }
+
+        if (emailExclude.isPresent()) {
+            filterPredicates.add(
+                    Predicates.getPredicateFindParticipantByEmail(emailNorm.get(), true));
+        }
+
+        if (phoneExclude.isPresent()) {
+            filterPredicates.add(
+                    Predicates.getPredicateFindParticipantByPhone(phoneNorm.get(), true));
+        }
+
+        this.findPredicate = type == FindCommandUtilEnum.AND
+                ? Predicates.predicateReducer(filterPredicates)
+                : Predicates.predicateReducerOr(filterPredicates);
+
+        this.nameNorm = nameNorm.orElse("");
+        this.emailNorm = emailNorm.orElse("");
+        this.phoneNorm = emailNorm.orElse("");
+        this.phoneNorm = emailNorm.orElse("");
+        this.nameExclude = nameExclude.orElse("");
+        this.emailExclude = emailExclude.orElse("");
+        this.phoneExclude = phoneExclude.orElse("");
     }
 
     @Override
@@ -80,8 +109,11 @@ public class FindParticipantCommand extends FindCommand {
             return false;
         }
 
-        return name.equals(((FindParticipantCommand) otherFindCommand).name)
-                && email.equals(((FindParticipantCommand) otherFindCommand).email)
-                && phone.equals(((FindParticipantCommand) otherFindCommand).phone);
+        return nameNorm.equals(((FindParticipantCommand) otherFindCommand).nameNorm)
+                && emailNorm.equals(((FindParticipantCommand) otherFindCommand).emailNorm)
+                && phoneNorm.equals(((FindParticipantCommand) otherFindCommand).phoneNorm)
+                && nameExclude.equals(((FindParticipantCommand) otherFindCommand).nameExclude)
+                && emailExclude.equals(((FindParticipantCommand) otherFindCommand).emailExclude)
+                && phoneExclude.equals(((FindParticipantCommand) otherFindCommand).phoneExclude);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/findcommand/FindTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/findcommand/FindTeamCommand.java
@@ -9,6 +9,7 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.Predicates;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.parser.findcommandparser.FindCommandUtilEnum;
 import seedu.address.model.Model;
 import seedu.address.model.entity.CommandType;
 import seedu.address.model.entity.PrefixType;
@@ -25,28 +26,48 @@ public class FindTeamCommand extends FindCommand {
             + "Example: " + COMMAND_WORD + " n/Team01";
     public static final String MESSAGE_SUCCESS = "Successfully ran the find command.";
 
-    private String name;
-    private String projectName;
+    private String nameNorm;
+    private String projectNameNorm;
+    private String nameExclude;
+    private String projectNameExclude;
     private Predicate<Team> findPredicate;
 
     public FindTeamCommand(
-            Optional<String> name,
-            Optional<String> projectName
+            FindCommandUtilEnum type,
+            Optional<String> nameNorm,
+            Optional<String> projectNameNorm,
+            Optional<String> nameExclude,
+            Optional<String> projectNameExclude
     ) {
-        List<Predicate<Team>> filteredParticipants = new ArrayList<>();
-        if (name.isPresent()) {
-            filteredParticipants.add(
-                    Predicates.getPredicateFindTeamByName(name.get()));
+        List<Predicate<Team>> filteredTeams = new ArrayList<>();
+        if (nameNorm.isPresent()) {
+            filteredTeams.add(
+                    Predicates.getPredicateFindTeamByName(nameNorm.get(), false));
         }
 
-        if (projectName.isPresent()) {
-            filteredParticipants.add(
-                    Predicates.getPredicateFindTeamByProjectName(projectName.get()));
+        if (projectNameNorm.isPresent()) {
+            filteredTeams.add(
+                    Predicates.getPredicateFindTeamByProjectName(projectNameNorm.get(), false));
         }
 
-        this.findPredicate = Predicates.predicateReducer(filteredParticipants);
-        this.name = name.orElse("");
-        this.projectName = projectName.orElse("");
+        if (nameExclude.isPresent()) {
+            filteredTeams.add(
+                    Predicates.getPredicateFindTeamByName(nameExclude.get(), true));
+        }
+
+        if (projectNameExclude.isPresent()) {
+            filteredTeams.add(
+                    Predicates.getPredicateFindTeamByProjectName(projectNameExclude.get(), true));
+        }
+
+        this.findPredicate = type == FindCommandUtilEnum.AND
+                ? Predicates.predicateReducer(filteredTeams)
+                : Predicates.predicateReducerOr(filteredTeams);
+
+        this.nameNorm = nameNorm.orElse("");
+        this.projectNameNorm = projectNameNorm.orElse("");
+        this.nameExclude = nameExclude.orElse("");
+        this.projectNameExclude = projectNameExclude.orElse("");
     }
 
     @Override
@@ -70,7 +91,9 @@ public class FindTeamCommand extends FindCommand {
             return false;
         }
 
-        return name.equals(((FindTeamCommand) otherFindCommand).name)
-                && projectName.equals(((FindTeamCommand) otherFindCommand).projectName);
+        return nameNorm.equals(((FindTeamCommand) otherFindCommand).nameNorm)
+                && projectNameNorm.equals(((FindTeamCommand) otherFindCommand).projectNameNorm)
+                && nameExclude.equals(((FindTeamCommand) otherFindCommand).nameExclude)
+                && projectNameExclude.equals(((FindTeamCommand) otherFindCommand).projectNameExclude);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AlfredParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/AlfredParserUtil.java
@@ -384,4 +384,27 @@ public class AlfredParserUtil {
         String andOrString = string.split(FindCommandUtilEnum.EXCLUDE.name())[0].trim();
         return andOrString;
     }
+
+    /**
+     * Pass in a string with the entity name removed.
+     *
+     * @param string which does not contain the entity type
+     * @throws ParseException if the AND or OR is not at the start of the string
+     */
+    public static void isFindTypeAtStart(String string) throws ParseException {
+        // We trim the string, then check if the first x letters are the keywords we expect
+        // Note: This function does not check for duplicate OR or AND declarations
+        // That is handled by getFindType
+        // Trim string at first just in case since having a starting space will cause bugs
+        string = string.trim();
+        if (string.contains(FindCommandUtilEnum.AND.name())) {
+            if (!string.startsWith(FindCommandUtilEnum.AND.name())) {
+                throw new ParseException("AND has to be before the prefixes");
+            }
+        } else if (string.contains(FindCommandUtilEnum.OR.name())) {
+            if (!string.startsWith(FindCommandUtilEnum.OR.name())) {
+                throw new ParseException("OR has to be before the prefixes");
+            }
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AlfredParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/AlfredParserUtil.java
@@ -327,6 +327,8 @@ public class AlfredParserUtil {
         } catch (NumberFormatException e) {
             throw new ParseException(Score.MESSAGE_CONSTRAINTS);
         }
+    }
+
     /**
      * Find the type of search we are going to perform.
      *

--- a/src/main/java/seedu/address/logic/parser/AlfredParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/AlfredParserUtil.java
@@ -19,6 +19,7 @@ import seedu.address.commons.util.LeaderboardUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.exceptions.ParseIdException;
+import seedu.address.logic.parser.findcommandparser.FindCommandUtilEnum;
 import seedu.address.model.entity.Email;
 import seedu.address.model.entity.Id;
 import seedu.address.model.entity.Location;
@@ -326,5 +327,61 @@ public class AlfredParserUtil {
         } catch (NumberFormatException e) {
             throw new ParseException(Score.MESSAGE_CONSTRAINTS);
         }
+    /**
+     * Find the type of search we are going to perform.
+     *
+     * @param string the user input string
+     */
+    public static FindCommandUtilEnum getFindType(String string) throws ParseException {
+        boolean isAndType = string.contains(FindCommandUtilEnum.AND.name());
+        boolean isOrType = string.contains(FindCommandUtilEnum.OR.name());
+
+        if (isAndType && isOrType) {
+            throw new ParseException("You cannot find by AND and OR");
+        }
+
+        // Default to AND if find type is not given
+        if (!isAndType && !isOrType) {
+            return FindCommandUtilEnum.AND;
+        }
+
+        return isAndType ? FindCommandUtilEnum.AND : FindCommandUtilEnum.OR;
+    }
+
+    /**
+     * This gets the String containing all the prefixes to be excluded.
+     *
+     * @param string
+     * @return the String containing the exclude clauses
+     * @throws ParseException if the input given is wrong
+     */
+    public static String getExcludeString(String string) throws ParseException {
+        String[] arr = string.split(FindCommandUtilEnum.EXCLUDE.name());
+        if (arr.length > 2) {
+            throw new ParseException("Only one EXCLUDE option should be given");
+        }
+        if (arr.length == 1) {
+            return "";
+        }
+        String negString = arr[1];
+
+        // Checks if the negative string is valid.
+        if (negString.contains(FindCommandUtilEnum.AND.name())
+                && negString.contains(FindCommandUtilEnum.OR.name())) {
+            throw new ParseException("Position your find types at the start");
+        }
+        return negString.trim();
+    }
+
+    /**
+     * Gets the AndOrString to parse for input.
+     *
+     * @param string
+     * @return String
+     * @throws ParseException if the input given is wrong.
+     */
+    public static String getAndOrString(String string) throws ParseException {
+        String andOrString = string.split(FindCommandUtilEnum.EXCLUDE.name())[0].trim();
+        return andOrString;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AlfredParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/AlfredParserUtil.java
@@ -367,7 +367,7 @@ public class AlfredParserUtil {
 
         // Checks if the negative string is valid.
         if (negString.contains(FindCommandUtilEnum.AND.name())
-                && negString.contains(FindCommandUtilEnum.OR.name())) {
+                || negString.contains(FindCommandUtilEnum.OR.name())) {
             throw new ParseException("Position your find types at the start");
         }
         return negString.trim();

--- a/src/main/java/seedu/address/logic/parser/findcommandparser/FindCommandUtilEnum.java
+++ b/src/main/java/seedu/address/logic/parser/findcommandparser/FindCommandUtilEnum.java
@@ -1,0 +1,10 @@
+package seedu.address.logic.parser.findcommandparser;
+
+/**
+ * This is a util enum for the find commands.
+ */
+public enum FindCommandUtilEnum {
+    AND,
+    OR,
+    EXCLUDE
+}

--- a/src/main/java/seedu/address/logic/parser/findcommandparser/FindMentorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/findcommandparser/FindMentorCommandParser.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import java.util.Optional;
 
 import seedu.address.logic.commands.findcommand.FindMentorCommand;
-import seedu.address.logic.parser.AlfredParser;
 import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -32,24 +31,36 @@ public class FindMentorCommandParser implements Parser<FindMentorCommand> {
         String andOrString = " " + AlfredParserUtil.getAndOrString(args);
         String excludeString = " " + AlfredParserUtil.getExcludeString(args);
 
-        ArgumentMultimap argumentMultimap =
+        ArgumentMultimap argumentMultimapNorm =
                 ArgumentTokenizer.tokenize(
-                        args, PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ORGANISATION);
+                        andOrString, PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ORGANISATION);
+        ArgumentMultimap argumentMultimapExclude =
+                ArgumentTokenizer.tokenize(
+                        excludeString, PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ORGANISATION);
 
-        Optional<String> name = argumentMultimap.getValue(PREFIX_NAME);
-        Optional<String> email = argumentMultimap.getValue(PREFIX_EMAIL);
-        Optional<String> phone = argumentMultimap.getValue(PREFIX_PHONE);
-        Optional<String> organization = argumentMultimap.getValue(PREFIX_ORGANISATION);
+        Optional<String> nameNorm = argumentMultimapNorm.getValue(PREFIX_NAME);
+        Optional<String> emailNorm = argumentMultimapNorm.getValue(PREFIX_EMAIL);
+        Optional<String> phoneNorm = argumentMultimapNorm.getValue(PREFIX_PHONE);
+        Optional<String> organizationNorm = argumentMultimapNorm.getValue(PREFIX_ORGANISATION);
 
-        boolean allPrefixesEmpty = name.isEmpty() && email.isEmpty()
-                && phone.isEmpty() && organization.isEmpty();
+        // Get negative prefixes
+        Optional<String> nameExclude = argumentMultimapExclude.getValue(PREFIX_NAME);
+        Optional<String> emailExclude = argumentMultimapExclude.getValue(PREFIX_EMAIL);
+        Optional<String> phoneExclude = argumentMultimapExclude.getValue(PREFIX_PHONE);
+        Optional<String> organizationExclude = argumentMultimapExclude.getValue(PREFIX_ORGANISATION);
+
+        boolean allPrefixesEmpty = nameNorm.isEmpty() && emailNorm.isEmpty()
+                && phoneNorm.isEmpty() && organizationNorm.isEmpty()
+                && nameExclude.isEmpty() && emailExclude.isEmpty()
+                && phoneExclude.isEmpty() && organizationExclude.isEmpty();
 
         if (allPrefixesEmpty) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     FindMentorCommand.MESSAGE_USAGE));
         }
 
-        return new FindMentorCommand(name, email, phone, organization);
+        return new FindMentorCommand(type, nameNorm, emailNorm, phoneNorm, organizationNorm,
+                nameExclude, emailExclude, phoneExclude, organizationExclude);
     }
 }
 

--- a/src/main/java/seedu/address/logic/parser/findcommandparser/FindMentorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/findcommandparser/FindMentorCommandParser.java
@@ -59,6 +59,9 @@ public class FindMentorCommandParser implements Parser<FindMentorCommand> {
                     FindMentorCommand.MESSAGE_USAGE));
         }
 
+        // Checks the position of the AND/OR
+        AlfredParserUtil.isFindTypeAtStart(args.trim().substring("mentor".length()));
+
         return new FindMentorCommand(type, nameNorm, emailNorm, phoneNorm, organizationNorm,
                 nameExclude, emailExclude, phoneExclude, organizationExclude);
     }

--- a/src/main/java/seedu/address/logic/parser/findcommandparser/FindMentorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/findcommandparser/FindMentorCommandParser.java
@@ -9,6 +9,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import java.util.Optional;
 
 import seedu.address.logic.commands.findcommand.FindMentorCommand;
+import seedu.address.logic.parser.AlfredParser;
+import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
@@ -26,6 +28,10 @@ public class FindMentorCommandParser implements Parser<FindMentorCommand> {
      * @throws ParseException if the user input does not conform to the expected format
      */
     public FindMentorCommand parse(String args) throws ParseException {
+        FindCommandUtilEnum type = AlfredParserUtil.getFindType(args);
+        String andOrString = " " + AlfredParserUtil.getAndOrString(args);
+        String excludeString = " " + AlfredParserUtil.getExcludeString(args);
+
         ArgumentMultimap argumentMultimap =
                 ArgumentTokenizer.tokenize(
                         args, PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ORGANISATION);

--- a/src/main/java/seedu/address/logic/parser/findcommandparser/FindParticipantCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/findcommandparser/FindParticipantCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import java.util.Optional;
 
 import seedu.address.logic.commands.findcommand.FindParticipantCommand;
+import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
@@ -25,21 +26,36 @@ public class FindParticipantCommandParser implements Parser<FindParticipantComma
      * @throws ParseException if the user input does not conform to the expected format
      */
     public FindParticipantCommand parse(String args) throws ParseException {
-        ArgumentMultimap argumentMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE);
+        FindCommandUtilEnum type = AlfredParserUtil.getFindType(args);
+        // Add space for ArgumentTokenizer to work correctly
+        String andOrString = " " + AlfredParserUtil.getAndOrString(args);
+        String excludeString = " " + AlfredParserUtil.getExcludeString(args);
 
-        Optional<String> name = argumentMultimap.getValue(PREFIX_NAME);
-        Optional<String> email = argumentMultimap.getValue(PREFIX_EMAIL);
-        Optional<String> phone = argumentMultimap.getValue(PREFIX_PHONE);
+        ArgumentMultimap argumentMultimapNorm =
+                ArgumentTokenizer.tokenize(andOrString, PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE);
+        ArgumentMultimap argumentMultimapExclude =
+                ArgumentTokenizer.tokenize(excludeString, PREFIX_NAME, PREFIX_EMAIL, PREFIX_PHONE);
+
+        Optional<String> nameNorm = argumentMultimapNorm.getValue(PREFIX_NAME);
+        Optional<String> emailNorm = argumentMultimapNorm.getValue(PREFIX_EMAIL);
+        Optional<String> phoneNorm = argumentMultimapNorm.getValue(PREFIX_PHONE);
+
+        // Get the negative strings here
+        Optional<String> nameExclude = argumentMultimapExclude.getValue(PREFIX_NAME);
+        Optional<String> emailExclude = argumentMultimapExclude.getValue(PREFIX_EMAIL);
+        Optional<String> phoneExclude = argumentMultimapExclude.getValue(PREFIX_PHONE);
 
         // If no prefixes given, we will throw an error later
-        boolean allPrefixesEmpty = name.isEmpty() && email.isEmpty() && phone.isEmpty();
+        boolean allPrefixesEmpty = nameNorm.isEmpty() && emailNorm.isEmpty()
+                && phoneNorm.isEmpty() && nameExclude.isEmpty()
+                && emailExclude.isEmpty() && phoneExclude.isEmpty();
 
         if (allPrefixesEmpty) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     FindParticipantCommand.MESSAGE_USAGE));
         }
 
-        return new FindParticipantCommand(name, email, phone);
+        return new FindParticipantCommand(type, nameNorm, emailNorm, phoneNorm,
+            nameExclude, emailExclude, phoneExclude);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/findcommandparser/FindParticipantCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/findcommandparser/FindParticipantCommandParser.java
@@ -55,6 +55,9 @@ public class FindParticipantCommandParser implements Parser<FindParticipantComma
                     FindParticipantCommand.MESSAGE_USAGE));
         }
 
+        // Checks the position of the AND/OR
+        AlfredParserUtil.isFindTypeAtStart(args.trim().substring("participant".length()));
+
         return new FindParticipantCommand(type, nameNorm, emailNorm, phoneNorm,
             nameExclude, emailExclude, phoneExclude);
     }

--- a/src/main/java/seedu/address/logic/parser/findcommandparser/FindTeamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/findcommandparser/FindTeamCommandParser.java
@@ -51,6 +51,9 @@ public class FindTeamCommandParser implements Parser<FindTeamCommand> {
                     FindTeamCommand.MESSAGE_USAGE));
         }
 
+        // Checks the position of the AND/OR
+        AlfredParserUtil.isFindTypeAtStart(args.trim().substring("team".length()));
+
         return new FindTeamCommand(type, nameNorm, projectNameNorm,
                 nameExclude, projectNameExclude);
     }

--- a/src/main/java/seedu/address/logic/parser/findcommandparser/FindTeamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/findcommandparser/FindTeamCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PROJECT_NAME;
 import java.util.Optional;
 
 import seedu.address.logic.commands.findcommand.FindTeamCommand;
+import seedu.address.logic.parser.AlfredParserUtil;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
@@ -24,19 +25,33 @@ public class FindTeamCommandParser implements Parser<FindTeamCommand> {
      * @throws ParseException if the user input does not conform to the expected format
      */
     public FindTeamCommand parse(String args) throws ParseException {
-        ArgumentMultimap argumentMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PROJECT_NAME);
+        System.out.println(args);
+        FindCommandUtilEnum type = AlfredParserUtil.getFindType(args);
+        // We pad an extra space before the strings else ArgumentTokenizer will not parse properly
+        String andOrString = " " + AlfredParserUtil.getAndOrString(args);
+        String excludeString = " " + AlfredParserUtil.getExcludeString(args);
 
-        Optional<String> name = argumentMultimap.getValue(PREFIX_NAME);
-        Optional<String> projectName = argumentMultimap.getValue(PREFIX_PROJECT_NAME);
+        ArgumentMultimap argumentMultimapNorm =
+                ArgumentTokenizer.tokenize(andOrString, PREFIX_NAME, PREFIX_PROJECT_NAME);
+        ArgumentMultimap argumentMultimapExclude = ArgumentTokenizer
+                .tokenize(excludeString, PREFIX_NAME, PREFIX_PROJECT_NAME);
 
-        boolean allPrefixesEmpty = name.isEmpty() && projectName.isEmpty();
+        Optional<String> nameNorm = argumentMultimapNorm.getValue(PREFIX_NAME);
+        Optional<String> projectNameNorm = argumentMultimapNorm.getValue(PREFIX_PROJECT_NAME);
+
+        // Negative Prefixes
+        Optional<String> nameExclude = argumentMultimapExclude.getValue(PREFIX_NAME);
+        Optional<String> projectNameExclude = argumentMultimapExclude.getValue(PREFIX_PROJECT_NAME);
+
+        boolean allPrefixesEmpty = nameNorm.isEmpty() && projectNameNorm.isEmpty()
+                && nameExclude.isEmpty() && projectNameExclude.isEmpty();
 
         if (allPrefixesEmpty) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     FindTeamCommand.MESSAGE_USAGE));
         }
 
-        return new FindTeamCommand(name, projectName);
+        return new FindTeamCommand(type, nameNorm, projectNameNorm,
+                nameExclude, projectNameExclude);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/findcommand/FindMentorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/findcommand/FindMentorCommandTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.AlfredException;
+import seedu.address.logic.parser.findcommandparser.FindCommandUtilEnum;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.testutil.TypicalMentors;
@@ -25,8 +26,13 @@ public class FindMentorCommandTest {
                 TypicalMentors.getTypicalMentors());
         doNothing().when(modelManager).updateHistory(any());
         FindMentorCommand command = new FindMentorCommand(
+                FindCommandUtilEnum.AND,
                 Optional.empty(),
                 Optional.of("email"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty()
         );
@@ -42,8 +48,13 @@ public class FindMentorCommandTest {
                 TypicalMentors.getTypicalMentors());
         doNothing().when(modelManager).updateHistory(any());
         FindMentorCommand command = new FindMentorCommand(
+                FindCommandUtilEnum.AND,
                 Optional.of("P"),
                 Optional.of("example"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty()
         );

--- a/src/test/java/seedu/address/logic/commands/findcommand/FindParticipantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/findcommand/FindParticipantCommandTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.AlfredException;
+import seedu.address.logic.parser.findcommandparser.FindCommandUtilEnum;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.testutil.TypicalParticipants;
@@ -25,7 +26,11 @@ public class FindParticipantCommandTest {
                  TypicalParticipants.getTypicalParticipants());
         doNothing().when(modelManager).updateHistory(any());
         FindParticipantCommand command = new FindParticipantCommand(
+                FindCommandUtilEnum.AND,
                 Optional.of("P"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty()
         );
@@ -41,8 +46,12 @@ public class FindParticipantCommandTest {
                 TypicalParticipants.getTypicalParticipants());
         doNothing().when(modelManager).updateHistory(any());
         FindParticipantCommand command = new FindParticipantCommand(
+                FindCommandUtilEnum.AND,
                 Optional.of("P"),
                 Optional.of("example"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty()
         );
         String expectedMessage = FindParticipantCommand.MESSAGE_SUCCESS;

--- a/src/test/java/seedu/address/logic/commands/findcommand/FindTeamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/findcommand/FindTeamCommandTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.AlfredException;
+import seedu.address.logic.parser.findcommandparser.FindCommandUtilEnum;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 
@@ -25,7 +26,10 @@ public class FindTeamCommandTest {
                 new ArrayList<>());
         doNothing().when(modelManager).updateHistory(any());
         FindTeamCommand command = new FindTeamCommand(
+                FindCommandUtilEnum.AND,
                 Optional.of("teamname"),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty()
         );
         String expectedMessage = FindTeamCommand.MESSAGE_SUCCESS;
@@ -40,8 +44,11 @@ public class FindTeamCommandTest {
                new ArrayList<>());
         doNothing().when(modelManager).updateHistory(any());
         FindTeamCommand command = new FindTeamCommand(
+                FindCommandUtilEnum.AND,
                 Optional.of("P"),
-                Optional.of("projectname")
+                Optional.of("projectname"),
+                Optional.empty(),
+                Optional.empty()
         );
         String expectedMessage = FindTeamCommand.MESSAGE_SUCCESS;
 

--- a/src/test/java/seedu/address/logic/parser/AlfredParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/AlfredParserUtilTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -264,5 +265,27 @@ public class AlfredParserUtilTest {
         assertThrows(ParseException.class, () -> AlfredParserUtil.getExcludeString(
                 "DAMITH EXCLUDE DAMITH AND damith is love"
         ));
+    }
+
+    @Test
+    void isFindTypeAtStart_noAndOrOr_success() throws ParseException {
+        assertDoesNotThrow(() -> AlfredParserUtil.isFindTypeAtStart("nice to meet you"));
+    }
+
+    @Test
+    void isFindTypeAtStart_andAtStart_success() throws ParseException {
+        assertDoesNotThrow(() -> AlfredParserUtil.isFindTypeAtStart("AND where you been"));
+    }
+
+    @Test
+    void isFindTypeAtStart_orAtStart_success() throws ParseException {
+        assertDoesNotThrow(() -> AlfredParserUtil.isFindTypeAtStart(" OR i could show "
+                + "you incredible things"));
+    }
+
+    @Test
+    void isFindTypeAtStart_andInMiddle_error() throws ParseException {
+        assertThrows(ParseException.class, () -> AlfredParserUtil.isFindTypeAtStart(" magic madness "
+                + "AND heaven sin"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AlfredParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/AlfredParserUtilTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.findcommandparser.FindCommandUtilEnum;
 import seedu.address.model.entity.Email;
 import seedu.address.model.entity.Id;
 import seedu.address.model.entity.Location;
@@ -227,4 +228,41 @@ public class AlfredParserUtilTest {
         assertThrows(ParseException.class, () -> AlfredParserUtil.getArgumentsFromCommand(SAMPLE_INVALID_COMMAND));
     }
 
+    @Test
+    void getFindType_noType_AND() throws ParseException {
+        assertEquals(FindCommandUtilEnum.AND, AlfredParserUtil.getFindType("heeehee"));
+    }
+
+    @Test
+    void getFindType_OR_OR() throws ParseException {
+        assertEquals(FindCommandUtilEnum.OR, AlfredParserUtil.getFindType("OR haha"));
+    }
+
+    @Test
+    void getFindType_both_throwsException() throws ParseException {
+        assertThrows(ParseException.class, () -> AlfredParserUtil.getFindType("AND eat OR shit"));
+    }
+
+    @Test
+    void getExcludeString_normal_success() throws ParseException {
+        assertEquals("yoyo", AlfredParserUtil.getExcludeString("haha EXCLUDE yoyo"));
+    }
+
+    @Test
+    void getExcludeString_noExclude_emptyString() throws ParseException {
+        assertEquals("", AlfredParserUtil.getExcludeString("nani"));
+    }
+
+    @Test
+    void getExcludeString_doubleExclude_error() throws ParseException {
+        assertThrows(ParseException.class, () -> AlfredParserUtil.getExcludeString(
+                "DAMITH EXCLUDE DAMITH EXCLUDE DAMITH"));
+    }
+
+    @Test
+    void getExcludeString_ANDinEXCLUDE_error() throws ParseException {
+        assertThrows(ParseException.class, () -> AlfredParserUtil.getExcludeString(
+                "DAMITH EXCLUDE DAMITH AND damith is love"
+        ));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/AlfredParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/AlfredParserUtilTest.java
@@ -229,12 +229,12 @@ public class AlfredParserUtilTest {
     }
 
     @Test
-    void getFindType_noType_AND() throws ParseException {
+    void getFindType_noType_success() throws ParseException {
         assertEquals(FindCommandUtilEnum.AND, AlfredParserUtil.getFindType("heeehee"));
     }
 
     @Test
-    void getFindType_OR_OR() throws ParseException {
+    void getFindType_or_success() throws ParseException {
         assertEquals(FindCommandUtilEnum.OR, AlfredParserUtil.getFindType("OR haha"));
     }
 
@@ -260,7 +260,7 @@ public class AlfredParserUtilTest {
     }
 
     @Test
-    void getExcludeString_ANDinEXCLUDE_error() throws ParseException {
+    void getExcludeString_andInExclude_error() throws ParseException {
         assertThrows(ParseException.class, () -> AlfredParserUtil.getExcludeString(
                 "DAMITH EXCLUDE DAMITH AND damith is love"
         ));

--- a/src/test/java/seedu/address/logic/parser/findcommandparser/FindCommandAllocatorTest.java
+++ b/src/test/java/seedu/address/logic/parser/findcommandparser/FindCommandAllocatorTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CommandAllocatorTestUtil.assertAllocato
 
 import java.util.Optional;
 
-import javax.swing.text.html.Option;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.findcommand.FindCommand;
@@ -25,7 +24,9 @@ public class FindCommandAllocatorTest {
     @Test
     void allocate_correctUserInput_success() {
         assertAllocatorSuccess(findCommandAllocator, "mentor n/Damith",
-                new FindMentorCommand(Optional.of("Damith"), Optional.empty(), Optional.empty(), Optional.empty()));
+                new FindMentorCommand(FindCommandUtilEnum.AND,
+                        Optional.of("Damith"), Optional.empty(), Optional.empty(), Optional.empty(),
+                        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         assertAllocatorSuccess(findCommandAllocator, "participant e/dog@gmail.com",
                 new FindParticipantCommand(FindCommandUtilEnum.AND,
                         Optional.empty(), Optional.of("dog@gmail.com"), Optional.empty(),

--- a/src/test/java/seedu/address/logic/parser/findcommandparser/FindCommandAllocatorTest.java
+++ b/src/test/java/seedu/address/logic/parser/findcommandparser/FindCommandAllocatorTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CommandAllocatorTestUtil.assertAllocato
 
 import java.util.Optional;
 
+import javax.swing.text.html.Option;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.findcommand.FindCommand;
@@ -26,9 +27,12 @@ public class FindCommandAllocatorTest {
         assertAllocatorSuccess(findCommandAllocator, "mentor n/Damith",
                 new FindMentorCommand(Optional.of("Damith"), Optional.empty(), Optional.empty(), Optional.empty()));
         assertAllocatorSuccess(findCommandAllocator, "participant e/dog@gmail.com",
-                new FindParticipantCommand(Optional.empty(), Optional.of("dog@gmail.com"), Optional.empty()));
+                new FindParticipantCommand(FindCommandUtilEnum.AND,
+                        Optional.empty(), Optional.of("dog@gmail.com"), Optional.empty(),
+                        Optional.empty(), Optional.empty(), Optional.empty()));
         assertAllocatorSuccess(findCommandAllocator, "team pn/djfnswdjf",
-                new FindTeamCommand(Optional.empty(), Optional.of("djfnswdjf")));
+                new FindTeamCommand(FindCommandUtilEnum.AND,
+                        Optional.empty(), Optional.of("djfnswdjf"), Optional.empty(), Optional.empty()));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/findcommandparser/FindMentorCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/findcommandparser/FindMentorCommandParserTest.java
@@ -16,7 +16,12 @@ public class FindMentorCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         assertParseSuccess(findMentorParser, "participant n/ifje",
-                new FindMentorCommand(Optional.of("ifje"),
+                new FindMentorCommand(FindCommandUtilEnum.AND,
+                        Optional.of("ifje"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty()));

--- a/src/test/java/seedu/address/logic/parser/findcommandparser/FindParticipantCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/findcommandparser/FindParticipantCommandParserTest.java
@@ -16,9 +16,15 @@ public class FindParticipantCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         assertParseSuccess(findParticipantParser, "participant n/ifje",
-                new FindParticipantCommand(Optional.of("ifje"),
+                new FindParticipantCommand(
+                        FindCommandUtilEnum.AND,
+                        Optional.of("ifje"),
                         Optional.empty(),
-                        Optional.empty()));
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()
+                ));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/findcommandparser/FindTeamCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/findcommandparser/FindTeamCommandParserTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 
 import java.util.Optional;
 
-import javax.swing.text.html.Option;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.findcommand.FindTeamCommand;

--- a/src/test/java/seedu/address/logic/parser/findcommandparser/FindTeamCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/findcommandparser/FindTeamCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 
 import java.util.Optional;
 
+import javax.swing.text.html.Option;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.findcommand.FindTeamCommand;
@@ -16,7 +17,11 @@ public class FindTeamCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         assertParseSuccess(findTeamParser, "team n/ifje",
-                new FindTeamCommand(Optional.of("ifje"),
+                new FindTeamCommand(
+                        FindCommandUtilEnum.AND,
+                        Optional.of("ifje"),
+                        Optional.empty(),
+                        Optional.empty(),
                         Optional.empty()));
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -239,7 +239,7 @@ public class ModelManagerTest {
         }
         assertEquals(modelManager.getMentorList().list().size(), 2);
         assertEquals(modelManager.findMentor(
-                Predicates.getPredicateFindMentorByName("B")).size(), 2);
+                Predicates.getPredicateFindMentorByName("B", false)).size(), 2);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -172,7 +172,7 @@ public class ModelManagerTest {
             // do nothing
         }
     }
-
+    names of each Entity, and does not search in other fields.
     @Test
     public void addParticipantToTeam_validParticipant_addsParticipant() {
         try {

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -172,7 +172,7 @@ public class ModelManagerTest {
             // do nothing
         }
     }
-    names of each Entity, and does not search in other fields.
+
     @Test
     public void addParticipantToTeam_validParticipant_addsParticipant() {
         try {
@@ -200,9 +200,9 @@ public class ModelManagerTest {
             modelManager.addParticipant(TypicalParticipants.B);
             assertEquals(modelManager.getParticipantList().list().size(), 2);
             assertEquals(modelManager.findParticipant(
-                    Predicates.getPredicateFindParticipantByName("A")).size(), 1);
+                    Predicates.getPredicateFindParticipantByName("A", false)).size(), 1);
             assertEquals(modelManager.findParticipant(
-                    Predicates.getPredicateFindParticipantByName("Part B")).size(), 1);
+                    Predicates.getPredicateFindParticipantByName("Part B", false)).size(), 1);
         } catch (AlfredException | IOException e) {
             // do nothing
         }
@@ -223,7 +223,7 @@ public class ModelManagerTest {
         }
         assertEquals(modelManager.getTeamList().list().size(), 1);
         assertEquals(modelManager.findTeam(
-                Predicates.getPredicateFindTeamByName("A")).size(), 1);
+                Predicates.getPredicateFindTeamByName("A", false)).size(), 1);
     }
     @Disabled
     @Test


### PR DESCRIPTION
## Description
Implements negative find and find by union options. This will be done thorough a `EXCLUDE` keyword at the input string. If they wanted to do a find by `OR` then they will just have to put the `OR` keyword at the start.

Note that due to the way `ArgumentTokenizer` works, only one instance of each prefix type is allowed in each section of the string, where each section is the EXCLUDE part and the other the normal part.

Searches by both AND and OR are not allowed.

If no `OR` or `AND` is given, then we default to find by intersection.

## Checks
- [x] No errors when running the tests
- [x] Build and checkstyle passes
- [] Run the app and ran 2 commands without failing
- [x] Written the baseline test cases for the PR

## Changelog
- [x] Added new parser methods in `AlfredParserUtil`
- [x] Changed the way the inputs are passed
- [x] Added a negativeArgMultipMap to get negative search.

## Comments for Reviewer (if any)
