### PR TITLE
Update get commands for model

### DIFF
--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -113,9 +113,9 @@ public interface Model {
 
     Team getTeam(Id teamId) throws AlfredException;
 
-    Team getTeamByParticipantId(Id participantId) throws AlfredException;
+    List<Team> getTeamByParticipantId(Id participantId) throws AlfredException;
 
-    Team getTeamByMentorId(Id mentorId) throws AlfredException;
+    List<Team> getTeamByMentorId(Id mentorId) throws AlfredException;
 
     void addTeam(Team team) throws AlfredException;
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,7 +24,6 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.AlfredException;
 import seedu.address.commons.exceptions.AlfredModelException;
 import seedu.address.commons.exceptions.AlfredModelHistoryException;
-import seedu.address.commons.exceptions.AlfredRuntimeException;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.exceptions.MissingEntityException;
 import seedu.address.commons.exceptions.ModelValidationException;
@@ -642,20 +641,8 @@ public class ModelManager implements Model {
         // First delete the Participant objects
         Team teamToDelete = this.teamList.delete(id);
 
-        boolean allParticipantsDeleted = true;
-        for (Participant p : teamToDelete.getParticipants()) {
-            try {
-                this.participantList.delete(p.getId());
-            } catch (MissingEntityException e) {
-                allParticipantsDeleted = false;
-            }
-        }
         this.saveList(PrefixType.T);
         this.saveList(PrefixType.P);
-
-        if (!allParticipantsDeleted) {
-            throw new AlfredRuntimeException("Duplicate assigning of teams for certain participants.");
-        }
 
         return teamToDelete;
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -326,9 +326,9 @@ public class ModelManager implements Model {
      * @param participant
      */
     public void updateParticipant(Id id, Participant participant) throws AlfredException {
-        Team targetTeam;
+        List<Team> targetTeams;
         try {
-            targetTeam = this.getTeamByParticipantId(id);
+            targetTeams = this.getTeamByParticipantId(id);
         } catch (MissingEntityException e) {
             this.participantList.update(id, participant);
             this.saveList(PrefixType.P);
@@ -336,9 +336,12 @@ public class ModelManager implements Model {
         }
         this.participantList.update(id, participant);
 
-        boolean isSuccessful = targetTeam.updateParticipant(participant);
+        boolean isSuccessful = targetTeams.stream()
+                .map(team -> team.updateParticipant(participant))
+                .allMatch(result -> result == true);
+
         if (!isSuccessful) {
-            logger.warning("The participant is not in the team provided");
+            logger.warning("The participant is not in the teams provided");
             throw new ModelValidationException("Participant is not in the team provided");
         }
 
@@ -356,14 +359,17 @@ public class ModelManager implements Model {
         Participant participantToDelete = this.participantList.delete(id); // May throw MissingEntityException here
         this.saveList(PrefixType.P);
 
-        Team targetTeam;
+        List<Team> targetTeams;
         try {
-            targetTeam = this.getTeamByParticipantId(id);
+            targetTeams = this.getTeamByParticipantId(id);
         } catch (MissingEntityException e) {
             return participantToDelete;
         }
 
-        boolean isSuccessful = targetTeam.deleteParticipant(participantToDelete);
+        boolean isSuccessful = targetTeams.stream()
+                .map(team -> team.updateParticipant(participantToDelete))
+                .allMatch(result -> result == true);
+
         if (!isSuccessful) {
             logger.warning("Participant does not exist");
             throw new ModelValidationException("Participant does not exist");
@@ -390,39 +396,47 @@ public class ModelManager implements Model {
      * Gets the team by participant id.
      *
      * @param participantId
-     * @return Team
+     * @return {@code List<Team>} which is the list of teams that contain the participant.
      * @throws MissingEntityException if the team to get does not exist.
      */
-    public Team getTeamByParticipantId(Id participantId) throws MissingEntityException {
+    public List<Team> getTeamByParticipantId(Id participantId) throws MissingEntityException {
         List<Team> teams = this.teamList.getSpecificTypedList();
+        List<Team> results = new ArrayList<>();
         for (Team t : teams) {
             for (Participant p : t.getParticipants()) {
                 if (p.getId().equals(participantId)) {
-                    return t;
+                    results.add(t);
                 }
             }
         }
-        throw new MissingEntityException("Team with said participant cannot be found.");
+        if (results.size() == 0) {
+            throw new MissingEntityException("Team with said participant cannot be found.");
+        }
+        return results;
     }
 
     /**
      * Gets the team by mentor id.
      *
      * @param mentorId
-     * @return Team
+     * @return {@code List<Team>} which is of the list of teams that contain the mentor
      * @throws MissingEntityException if the team to get does not exist.
      */
-    public Team getTeamByMentorId(Id mentorId) throws MissingEntityException {
+    public List<Team> getTeamByMentorId(Id mentorId) throws MissingEntityException {
         List<Team> teams = this.teamList.getSpecificTypedList();
+        List<Team> results = new ArrayList<>();
         for (Team t : teams) {
             Optional<Mentor> mentor = t.getMentor();
             if (mentor.isPresent()) {
                 if (mentor.get().getId().equals(mentorId)) {
-                    return t;
+                    results.add(t);
                 }
             }
         }
-        throw new MissingEntityException("Team with said mentor cannot be found.");
+        if (results.size() == 0) {
+            throw new MissingEntityException("Team with said participant cannot be found.");
+        }
+        return results;
     }
 
     /**
@@ -677,9 +691,9 @@ public class ModelManager implements Model {
      * @param updatedMentor
      */
     public void updateMentor(Id id, Mentor updatedMentor) throws AlfredException {
-        Team targetTeam;
+        List<Team> targetTeams;
         try {
-            targetTeam = this.getTeamByMentorId(id);
+            targetTeams = this.getTeamByMentorId(id);
         } catch (MissingEntityException e) {
             this.mentorList.update(id, updatedMentor);
             this.saveList(PrefixType.M);
@@ -687,7 +701,9 @@ public class ModelManager implements Model {
         }
 
         this.mentorList.update(id, updatedMentor);
-        boolean isSuccessful = targetTeam.updateMentor(updatedMentor);
+        boolean isSuccessful = targetTeams.stream()
+                .map(team -> team.updateMentor(updatedMentor))
+                .allMatch(result -> result == true);
         if (!isSuccessful) {
             logger.severe("Unable to update the mentor in team as it is not the " + "same id");
             throw new ModelValidationException("Unable to update the mentor in team as it is not the " + "same id");
@@ -708,14 +724,16 @@ public class ModelManager implements Model {
         Mentor mentorToDelete = this.mentorList.delete(id); // May throw MissingEntityException here
         this.saveList(PrefixType.M);
 
-        Team targetTeam;
+        List<Team> targetTeams;
         try {
-            targetTeam = this.getTeamByMentorId(id);
+            targetTeams = this.getTeamByMentorId(id);
         } catch (MissingEntityException e) {
             return mentorToDelete;
         }
 
-        boolean isSuccessful = targetTeam.deleteMentor(mentorToDelete);
+        boolean isSuccessful = targetTeams.stream()
+                .map(team -> team.deleteMentor(mentorToDelete))
+                .allMatch(result -> result == true);
         if (!isSuccessful) {
             logger.severe("Unable to delete the mentor from the team");
             throw new AlfredModelException("Update to delete the mentor from the team");

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -724,7 +724,7 @@ public class ModelManagerTest {
         m.addParticipantToTeam(TypicalTeams.EMPTY.getId(), TypicalParticipants.A);
         m.addParticipantToTeam(TypicalTeams.EMPTY.getId(), TypicalParticipants.B);
         assertEquals(TypicalTeams.EMPTY, m.deleteTeam(TypicalTeams.EMPTY.getId()));
-        assertEquals(m.getParticipantList().list().size(), 0);
+        assertEquals(m.getParticipantList().list().size(), 2);
     }
 
     @Test
@@ -737,6 +737,49 @@ public class ModelManagerTest {
         m.addTeam(TypicalTeams.EMPTY);
         assertThrows(MissingEntityException.class, () -> m.deleteTeam(
                 TypicalTeams.D.getId()));
+    }
+
+    @Test
+    public void getTeamByParticipantId_validId_success() throws AlfredException {
+        ModelManager m = new ModelManager(this.storage, this.userPrefs);
+        TypicalTeams.clearTeamEmpty();
+        m.addParticipant(TypicalParticipants.A);
+        m.addMentor(TypicalMentors.A);
+        m.addParticipant(TypicalParticipants.B);
+        m.addTeam(TypicalTeams.EMPTY);
+        m.addTeam(TypicalTeams.A);
+        m.addParticipantToTeam(TypicalTeams.EMPTY.getId(), TypicalParticipants.A);
+        assertEquals(m.getTeamByParticipantId(TypicalParticipants.A.getId()).size(), 2);
+    }
+
+    @Test
+    public void getTeamByParticipantId_noTeam_error() throws AlfredException {
+        ModelManager m = new ModelManager(this.storage, this.userPrefs);
+        TypicalTeams.clearTeamEmpty();
+        m.addTeam(TypicalTeams.EMPTY);
+        assertThrows(MissingEntityException.class, () -> m.getTeamByParticipantId(
+                TypicalParticipants.B.getId()));
+    }
+
+    @Test
+    public void getTeamByMentorId_validId_success() throws AlfredException {
+        ModelManager m = new ModelManager(this.storage, this.userPrefs);
+        TypicalTeams.clearTeamEmpty();
+        m.addParticipant(TypicalParticipants.A);
+        m.addMentor(TypicalMentors.A);
+        m.addTeam(TypicalTeams.EMPTY);
+        m.addTeam(TypicalTeams.A);
+        m.addMentorToTeam(TypicalTeams.EMPTY.getId(), TypicalMentors.A);
+        assertEquals(m.getTeamByMentorId(TypicalMentors.A.getId()).size(), 2);
+    }
+
+    @Test
+    public void getTeamByMentorId_noTeam_error() throws AlfredException {
+        ModelManager m = new ModelManager(this.storage, this.userPrefs);
+        TypicalTeams.clearTeamEmpty();
+        m.addTeam(TypicalTeams.EMPTY);
+        assertThrows(MissingEntityException.class, () -> m.getTeamByMentorId(
+                TypicalMentors.B.getId()));
     }
 
     @Test


### PR DESCRIPTION
## Description

Thanks @john0227 for the catch. Currently, the issue with update and delete mentor/participant is the get command only returns the first team it finds with the mentorid/participant id.
Therefore, if said mentor is in multiple teams, only one team with the mentor is being updated, which is wrong

**IMPORTANT CHANGE**: *Now, if we delete team, the participants in that team will no longer be deleted*

To rectify this, we return a list of teams with the getTeamByParticipant/Mentor id and then map over to delete/update all the participants/mentors in all teams to ensure that all teams with the said entity are properly processed and validated

## Checks
- [x] No errors when running the tests
- [x] Build and checkstyle passes
- [x] Run the app and ran 2 commands without failing
- [x] Written the baseline test cases for the PR

## Changelog
- [x] `ModelManager`
- [x] Test
- [x] ModelManagerStub

## Comments for Reviewer (if any)
@john0227 Right now it does a simple map to check. However, I'm not exactly sure what we should do when the update/delete operation fails for a certain team. 
No 1, I'm not sure if this error would possibly occur in the first place, 
No 2, if it could happen, Im not sure what actions we should take. I suppose we could delete the mentor/participant on the team with the failed update/delete, but this seems to be too drastic. Neither is blocking the user from doing anything the right idea. 

Also welcome input from anyone else on this issue